### PR TITLE
Add user profile page with account settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Change email address (requires password confirmation)
   - Change password (invalidates all refresh tokens for security)
   - Upload, change, or remove profile photo
+  - Tasting profile section with bio, favorite whiskey category, and experience level
 - Profile link in header navigation (click username to access)
 - Profile photo upload functionality
   - Supports JPEG, PNG, GIF, and WebP formats (max 5MB)
   - Avatar displayed in header navigation and profile page
   - Automatic cleanup of old avatars when uploading new ones
+- Tasting profile features
+  - Bio/tagline (up to 200 characters)
+  - Favorite whiskey category (bourbon, rye, scotch, irish, japanese, canadian, other)
+  - Experience level indicator (beginner, intermediate, advanced, expert)
 - `setUser` action in auth store for updating user state
 
 ### Changed

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -3,6 +3,12 @@ import { sqliteTable, text, integer, real } from 'drizzle-orm/sqlite-core';
 // User roles
 export type UserRole = 'user' | 'admin';
 
+// Experience levels
+export type ExperienceLevel = 'beginner' | 'intermediate' | 'advanced' | 'expert';
+
+// Whiskey categories
+export type WhiskeyCategory = 'bourbon' | 'rye' | 'scotch' | 'irish' | 'japanese' | 'canadian' | 'other';
+
 // Users table
 export const users = sqliteTable('users', {
   id: text('id').primaryKey(),
@@ -10,6 +16,9 @@ export const users = sqliteTable('users', {
   passwordHash: text('password_hash').notNull(),
   displayName: text('display_name').notNull(),
   avatarUrl: text('avatar_url'), // Profile photo URL
+  bio: text('bio'), // Short bio/tagline
+  favoriteCategory: text('favorite_category'), // Favorite whiskey category
+  experienceLevel: text('experience_level'), // Tasting experience level
   role: text('role').notNull().default('user'), // 'user' or 'admin'
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
 });

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -3,12 +3,17 @@ import { persist, devtools } from 'zustand/middleware';
 import { authApi } from '@/services';
 
 export type UserRole = 'user' | 'admin';
+export type ExperienceLevel = 'beginner' | 'intermediate' | 'advanced' | 'expert';
+export type WhiskeyCategory = 'bourbon' | 'rye' | 'scotch' | 'irish' | 'japanese' | 'canadian' | 'other';
 
 interface User {
   id: string;
   email: string;
   displayName: string;
   avatarUrl?: string | null;
+  bio?: string | null;
+  favoriteCategory?: WhiskeyCategory | null;
+  experienceLevel?: ExperienceLevel | null;
   role: UserRole;
 }
 
@@ -108,6 +113,9 @@ export const useAuthStore = create<AuthState>()(
                 email: user.email,
                 displayName: user.displayName,
                 avatarUrl: user.avatarUrl,
+                bio: user.bio,
+                favoriteCategory: user.favoriteCategory as WhiskeyCategory | null | undefined,
+                experienceLevel: user.experienceLevel as ExperienceLevel | null | undefined,
                 role,
               },
               isAuthenticated: true,
@@ -127,6 +135,9 @@ export const useAuthStore = create<AuthState>()(
                   email: user.email,
                   displayName: user.displayName,
                   avatarUrl: user.avatarUrl,
+                  bio: user.bio,
+                  favoriteCategory: user.favoriteCategory as WhiskeyCategory | null | undefined,
+                  experienceLevel: user.experienceLevel as ExperienceLevel | null | undefined,
                   role,
                 },
                 isAuthenticated: true,


### PR DESCRIPTION
## Summary
- Add user profile page (`/profile`) for managing account settings
- Profile photo upload with support for JPEG, PNG, GIF, WebP (max 5MB)
- Tasting profile with bio, favorite whiskey category, and experience level
- Change display name, email (with password confirmation), and password
- Add CLAUDE.md for Claude Code development guidance
- Add CHANGELOG.md to track project changes

## Test plan
- [ ] Navigate to `/profile` when logged in
- [ ] Upload, change, and remove profile photo
- [ ] Update display name and verify it appears in header
- [ ] Update email with correct password confirmation
- [ ] Change password and verify old sessions are invalidated
- [ ] Set bio, favorite category, and experience level
- [ ] Verify profile data persists after logout/login

🤖 Generated with [Claude Code](https://claude.ai/code)