### PR TITLE
Add user profiles, social features, and tasting statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- User profile page (`/profile`) for account settings
-  - Change display name
-  - Change email address (requires password confirmation)
-  - Change password (invalidates all refresh tokens for security)
-  - Upload, change, or remove profile photo
-  - Tasting profile section with bio, favorite whiskey category, and experience level
-- Profile link in header navigation (click username to access)
-- Profile photo upload functionality
-  - Supports JPEG, PNG, GIF, and WebP formats (max 5MB)
-  - Avatar displayed in header navigation and profile page
-  - Automatic cleanup of old avatars when uploading new ones
-- Tasting profile features
-  - Bio/tagline (up to 200 characters)
-  - Favorite whiskey category (bourbon, rye, scotch, irish, japanese, canadian, other)
-  - Experience level indicator (beginner, intermediate, advanced, expert)
-- `setUser` action in auth store for updating user state
+- Tasting statistics on public profiles
+  - Sessions attended count
+  - Whiskeys rated count
+  - Categories explored with labels
+  - Score distribution visualization
+  - Scoring tendency analysis (generous/balanced/critical)
+  - Average scores by category (nose, palate, finish, overall)
+  - Frequently used tasting notes
+  - Recent session activity
+- Achievement/badge system
+  - 13 achievements across 4 categories (sessions, whiskeys, exploration, hosting)
+  - Progress tracking for unearned achievements
+  - Visual badges with category-specific icons
+  - Achievement summary with completion percentage
+- Tabbed interface on public profiles (Stats, Achievements, Notes)
+
+## [78ec1ff] - 2026-01-24
+
+### Added
 - Social features
   - Follow/unfollow other users
   - View followers list (`/user/:userId/followers`)
@@ -48,10 +51,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Privacy toggle endpoint
   - Public tasting notes endpoint
 
+## [716524c] - 2026-01-24
+
+### Added
+- Tasting profile features
+  - Bio/tagline (up to 200 characters)
+  - Favorite whiskey category (bourbon, rye, scotch, irish, japanese, canadian, other)
+  - Experience level indicator (beginner, intermediate, advanced, expert)
+- `setUser` action in auth store for updating user state
+
+## [e403a36] - 2026-01-24
+
+### Added
+- CLAUDE.md for Claude Code guidance
+
+## [5fcf24b] - 2026-01-24
+
+### Added
+- Profile photo upload functionality
+  - Supports JPEG, PNG, GIF, and WebP formats (max 5MB)
+  - Avatar displayed in header navigation and profile page
+  - Automatic cleanup of old avatars when uploading new ones
+
 ### Changed
 - Header now shows avatar and clickable username linking to profile page
 
-## [0.1.0] - 2026-01-24
+## [00d543e] - 2026-01-24
+
+### Added
+- User profile page (`/profile`) for account settings
+  - Change display name
+  - Change email address (requires password confirmation)
+  - Change password (invalidates all refresh tokens for security)
+- Profile link in header navigation (click username to access)
+
+## [cbfc54d] - 2026-01-24
+
+### Added
+- Email validation on registration (RFC 5322 compliant, blocks disposable emails)
+
+## [797ea73] - 2026-01-24
+
+### Added
+- Apache 2.0 License
+
+## [1ad64ae] - 2026-01-24
+
+### Changed
+- Updated README with setup instructions and API documentation
+
+## [d37f97b] - 2026-01-24
 
 ### Added
 - Initial release of Whiskey Canon Blinds
@@ -65,7 +114,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - User authentication with JWT (access + refresh + participant tokens)
 - Role-based access control (user/admin roles)
 - Admin dashboard for user and session management
-- Email validation on registration (RFC 5322 compliant, blocks disposable emails)
 - Responsive dark theme UI with Tailwind CSS
 - Navigation header and footer on all pages
 
@@ -73,7 +121,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Frontend: React 19, TypeScript, Vite, Zustand, React Router v7
 - Backend: Node.js, Express 5, SQLite, Drizzle ORM, Socket.io
 - Authentication: JWT with bcrypt password hashing
-
-### Documentation
-- README.md with setup instructions and API documentation
-- Apache 2.0 License

--- a/src/components/social/AchievementBadge.tsx
+++ b/src/components/social/AchievementBadge.tsx
@@ -1,0 +1,213 @@
+interface Achievement {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  category: string;
+  earned: boolean;
+  progress: number;
+  target: number;
+}
+
+interface AchievementBadgeProps {
+  achievement: Achievement;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+// Icon components for achievements
+const ICONS: Record<string, JSX.Element> = {
+  glass: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      <path d="M6 2h12l-1.5 14h-9L6 2zm6 18c-2 0-3-1-3-2h6c0 1-1 2-3 2zm-2-4h4v2h-4v-2z" />
+    </svg>
+  ),
+  calendar: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      <path d="M19 4h-1V2h-2v2H8V2H6v2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V10h14v10zM5 8V6h14v2H5z" />
+    </svg>
+  ),
+  star: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+    </svg>
+  ),
+  trophy: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      <path d="M19 5h-2V3H7v2H5c-1.1 0-2 .9-2 2v1c0 2.55 1.92 4.63 4.39 4.94.63 1.5 1.98 2.63 3.61 2.96V19H8v2h8v-2h-3v-3.1c1.63-.33 2.98-1.46 3.61-2.96C19.08 12.63 21 10.55 21 8V7c0-1.1-.9-2-2-2zM5 8V7h2v3.82C5.84 10.4 5 9.3 5 8zm14 0c0 1.3-.84 2.4-2 2.82V7h2v1z" />
+    </svg>
+  ),
+  bottle: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      <path d="M10 2v2.26l-1.5 3V10h-1v10c0 1.1.9 2 2 2h5c1.1 0 2-.9 2-2V10h-1V7.26l-1.5-3V2h-4zm1 2h2v1.51l1.5 3V10h-5V8.51l1.5-3V4z" />
+    </svg>
+  ),
+  bottles: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      <path d="M4 2v3l2 3v2H4v10c0 1 1 2 2 2h3c1 0 2-1 2-2V10H9V8l2-3V2H4zm14 0v3l2 3v2h-2v10c0 1 1 2 2 2h3c1 0 2-1 2-2V10h-2V8l2-3V2h-7z" />
+    </svg>
+  ),
+  collection: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      <path d="M3 3h8v8H3V3zm2 2v4h4V5H5zm8-2h8v8h-8V3zm2 2v4h4V5h-4zM3 13h8v8H3v-8zm2 2v4h4v-4H5zm8-2h8v8h-8v-8zm2 2v4h4v-4h-4z" />
+    </svg>
+  ),
+  medal: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      <path d="M12 2C8.13 2 5 5.13 5 9c0 2.38 1.19 4.47 3 5.74V22l4-2 4 2v-7.26c1.81-1.27 3-3.36 3-5.74 0-3.87-3.13-7-7-7zm0 2c2.76 0 5 2.24 5 5s-2.24 5-5 5-5-2.24-5-5 2.24-5 5-5z" />
+    </svg>
+  ),
+  compass: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
+    </svg>
+  ),
+  globe: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z" />
+    </svg>
+  ),
+  world: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z" />
+      <path d="M12 6c-3.31 0-6 2.69-6 6s2.69 6 6 6 6-2.69 6-6-2.69-6-6-6zm0 10c-2.21 0-4-1.79-4-4s1.79-4 4-4 4 1.79 4 4-1.79 4-4 4z" />
+    </svg>
+  ),
+  host: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z" />
+    </svg>
+  ),
+  crown: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      <path d="M2 19h20v3H2v-3zm2-8l3 5h10l3-5-4 2-4-6-4 6-4-2z" />
+    </svg>
+  ),
+  scepter: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      <path d="M12 1l3 5-3 2-3-2 3-5zm0 9l-2 12h4l-2-12zm-5-2l2.5 4L7 14l-5-3 5-3zm10 0l-2.5 4 2.5 2 5-3-5-3z" />
+    </svg>
+  ),
+};
+
+const DEFAULT_ICON = (
+  <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+    <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+  </svg>
+);
+
+const SIZES = {
+  sm: { badge: 'w-12 h-12', icon: 'w-6 h-6', text: 'text-xs' },
+  md: { badge: 'w-16 h-16', icon: 'w-8 h-8', text: 'text-sm' },
+  lg: { badge: 'w-20 h-20', icon: 'w-10 h-10', text: 'text-base' },
+};
+
+export function AchievementBadge({ achievement, size = 'md' }: AchievementBadgeProps) {
+  const sizeClasses = SIZES[size];
+  const progressPercent = (achievement.progress / achievement.target) * 100;
+
+  return (
+    <div className="flex flex-col items-center gap-2 p-3">
+      {/* Badge Circle */}
+      <div className="relative">
+        <div
+          className={`${sizeClasses.badge} rounded-full flex items-center justify-center transition-all ${
+            achievement.earned
+              ? 'bg-gradient-to-br from-amber-400 to-amber-600 shadow-lg shadow-amber-500/30'
+              : 'bg-zinc-800 border-2 border-zinc-700'
+          }`}
+        >
+          <div
+            className={`${sizeClasses.icon} ${
+              achievement.earned ? 'text-zinc-900' : 'text-zinc-600'
+            }`}
+          >
+            {ICONS[achievement.icon] || DEFAULT_ICON}
+          </div>
+        </div>
+
+        {/* Progress Ring for unearned achievements */}
+        {!achievement.earned && achievement.progress > 0 && (
+          <svg
+            className={`absolute inset-0 ${sizeClasses.badge} -rotate-90`}
+            viewBox="0 0 100 100"
+          >
+            <circle
+              cx="50"
+              cy="50"
+              r="46"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="8"
+              className="text-amber-500/30"
+              strokeDasharray={`${progressPercent * 2.89} 289`}
+            />
+          </svg>
+        )}
+      </div>
+
+      {/* Badge Name */}
+      <div className="text-center">
+        <div
+          className={`${sizeClasses.text} font-medium ${
+            achievement.earned ? 'text-zinc-100' : 'text-zinc-500'
+          }`}
+        >
+          {achievement.name}
+        </div>
+        {!achievement.earned && (
+          <div className="text-xs text-zinc-600">
+            {achievement.progress}/{achievement.target}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface AchievementsGridProps {
+  achievements: Achievement[];
+  showUnearned?: boolean;
+}
+
+export function AchievementsGrid({ achievements, showUnearned = true }: AchievementsGridProps) {
+  const displayAchievements = showUnearned
+    ? achievements
+    : achievements.filter((a) => a.earned);
+
+  // Group by category
+  const categories: Record<string, Achievement[]> = {};
+  displayAchievements.forEach((a) => {
+    if (!categories[a.category]) {
+      categories[a.category] = [];
+    }
+    categories[a.category].push(a);
+  });
+
+  const CATEGORY_LABELS: Record<string, string> = {
+    sessions: 'Tasting Sessions',
+    whiskeys: 'Whiskeys Rated',
+    exploration: 'Category Exploration',
+    hosting: 'Hosting',
+  };
+
+  return (
+    <div className="space-y-6">
+      {Object.entries(categories).map(([category, categoryAchievements]) => (
+        <div key={category}>
+          <h4 className="text-sm font-medium text-zinc-400 mb-3">
+            {CATEGORY_LABELS[category] || category}
+          </h4>
+          <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-2">
+            {categoryAchievements.map((achievement) => (
+              <AchievementBadge
+                key={achievement.id}
+                achievement={achievement}
+                size="sm"
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/social/TastingStats.tsx
+++ b/src/components/social/TastingStats.tsx
@@ -1,0 +1,188 @@
+import { Card, CardContent } from '@/components/ui';
+
+interface TastingStatsProps {
+  stats: {
+    overview: {
+      sessionsAttended: number;
+      whiskeysRated: number;
+      categoriesExplored: string[];
+    };
+    scoringTendencies: {
+      averages: {
+        nose: number;
+        palate: number;
+        finish: number;
+        overall: number;
+        total: number;
+      };
+      distribution: Record<number, number>;
+      tendency: 'generous' | 'balanced' | 'critical';
+    };
+    favoriteNotes: Array<{ term: string; count: number }>;
+    recentActivity: Array<{
+      id: string;
+      name: string;
+      theme: string;
+      completedAt: string;
+    }>;
+  };
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  bourbon: 'Bourbon',
+  rye: 'Rye',
+  scotch: 'Scotch',
+  'scotch-single-malt': 'Single Malt Scotch',
+  'scotch-blended': 'Blended Scotch',
+  irish: 'Irish',
+  japanese: 'Japanese',
+  canadian: 'Canadian',
+  world: 'World Whiskey',
+  custom: 'Custom',
+};
+
+const TENDENCY_LABELS: Record<string, { label: string; color: string }> = {
+  generous: { label: 'Generous Scorer', color: 'text-green-400' },
+  balanced: { label: 'Balanced Scorer', color: 'text-amber-400' },
+  critical: { label: 'Critical Scorer', color: 'text-blue-400' },
+};
+
+export function TastingStats({ stats }: TastingStatsProps) {
+  const maxDistribution = Math.max(...Object.values(stats.scoringTendencies.distribution), 1);
+
+  return (
+    <div className="space-y-6">
+      {/* Overview Stats */}
+      <div className="grid grid-cols-3 gap-4">
+        <Card variant="outlined">
+          <CardContent className="text-center py-4">
+            <div className="text-3xl font-bold text-amber-500">
+              {stats.overview.sessionsAttended}
+            </div>
+            <div className="text-sm text-zinc-400">Sessions</div>
+          </CardContent>
+        </Card>
+        <Card variant="outlined">
+          <CardContent className="text-center py-4">
+            <div className="text-3xl font-bold text-amber-500">
+              {stats.overview.whiskeysRated}
+            </div>
+            <div className="text-sm text-zinc-400">Whiskeys Rated</div>
+          </CardContent>
+        </Card>
+        <Card variant="outlined">
+          <CardContent className="text-center py-4">
+            <div className="text-3xl font-bold text-amber-500">
+              {stats.overview.categoriesExplored.length}
+            </div>
+            <div className="text-sm text-zinc-400">Categories</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Categories Explored */}
+      {stats.overview.categoriesExplored.length > 0 && (
+        <div>
+          <h4 className="text-sm font-medium text-zinc-400 mb-2">Categories Explored</h4>
+          <div className="flex flex-wrap gap-2">
+            {stats.overview.categoriesExplored.map((cat) => (
+              <span
+                key={cat}
+                className="px-3 py-1 bg-zinc-800 text-zinc-300 rounded-full text-sm"
+              >
+                {CATEGORY_LABELS[cat] || cat}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Scoring Tendencies */}
+      {stats.overview.whiskeysRated > 0 && (
+        <Card variant="outlined">
+          <CardContent>
+            <div className="flex items-center justify-between mb-4">
+              <h4 className="text-sm font-medium text-zinc-400">Scoring Tendencies</h4>
+              <span className={`text-sm font-medium ${TENDENCY_LABELS[stats.scoringTendencies.tendency].color}`}>
+                {TENDENCY_LABELS[stats.scoringTendencies.tendency].label}
+              </span>
+            </div>
+
+            {/* Average Scores */}
+            <div className="grid grid-cols-5 gap-2 mb-6">
+              {Object.entries(stats.scoringTendencies.averages).map(([key, value]) => (
+                <div key={key} className="text-center">
+                  <div className="text-lg font-bold text-zinc-100">{value.toFixed(1)}</div>
+                  <div className="text-xs text-zinc-500 capitalize">{key === 'total' ? 'Avg' : key}</div>
+                </div>
+              ))}
+            </div>
+
+            {/* Score Distribution */}
+            <div>
+              <div className="text-xs text-zinc-500 mb-2">Score Distribution</div>
+              <div className="flex items-end gap-1 h-16">
+                {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((score) => {
+                  const count = stats.scoringTendencies.distribution[score] || 0;
+                  const height = maxDistribution > 0 ? (count / maxDistribution) * 100 : 0;
+                  return (
+                    <div key={score} className="flex-1 flex flex-col items-center">
+                      <div
+                        className="w-full bg-amber-500/60 rounded-t transition-all"
+                        style={{ height: `${Math.max(height, 4)}%` }}
+                        title={`Score ${score}: ${count} ratings`}
+                      />
+                      <div className="text-xs text-zinc-600 mt-1">{score}</div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Favorite Notes */}
+      {stats.favoriteNotes.length > 0 && (
+        <div>
+          <h4 className="text-sm font-medium text-zinc-400 mb-2">Frequently Used Tasting Notes</h4>
+          <div className="flex flex-wrap gap-2">
+            {stats.favoriteNotes.map((note) => (
+              <span
+                key={note.term}
+                className="px-3 py-1 bg-amber-500/20 text-amber-400 rounded-full text-sm"
+              >
+                {note.term} ({note.count})
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Recent Activity */}
+      {stats.recentActivity.length > 0 && (
+        <div>
+          <h4 className="text-sm font-medium text-zinc-400 mb-2">Recent Sessions</h4>
+          <div className="space-y-2">
+            {stats.recentActivity.map((session) => (
+              <div
+                key={session.id}
+                className="flex items-center justify-between p-3 bg-zinc-800/50 rounded-lg"
+              >
+                <div>
+                  <div className="text-zinc-100">{session.name}</div>
+                  <div className="text-xs text-zinc-500">
+                    {CATEGORY_LABELS[session.theme] || session.theme}
+                  </div>
+                </div>
+                <div className="text-xs text-zinc-500">
+                  {new Date(session.completedAt).toLocaleDateString()}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/social/index.ts
+++ b/src/components/social/index.ts
@@ -2,3 +2,5 @@ export { FollowButton } from './FollowButton';
 export { UserCard } from './UserCard';
 export { ProfileStats } from './ProfileStats';
 export { TastingNoteCard } from './TastingNoteCard';
+export { TastingStats } from './TastingStats';
+export { AchievementBadge, AchievementsGrid } from './AchievementBadge';

--- a/src/pages/PublicProfile.tsx
+++ b/src/pages/PublicProfile.tsx
@@ -1,24 +1,33 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { Card, CardContent, Button } from '@/components/ui';
-import { FollowButton, ProfileStats, TastingNoteCard } from '@/components/social';
+import { FollowButton, ProfileStats, TastingNoteCard, TastingStats, AchievementsGrid } from '@/components/social';
 import { useSocialStore } from '@/store/socialStore';
 import { useAuthStore } from '@/store/authStore';
 
 const SERVER_URL = import.meta.env.VITE_API_URL?.replace('/api', '') || 'http://localhost:3001';
 
+type TabType = 'notes' | 'stats' | 'achievements';
+
 export function PublicProfilePage() {
   const { userId } = useParams<{ userId: string }>();
   const { user: currentUser, isAuthenticated } = useAuthStore();
+  const [activeTab, setActiveTab] = useState<TabType>('stats');
   const {
     profile,
     publicNotes,
     notesPagination,
+    tastingStats,
+    achievements,
     isLoadingProfile,
     isLoadingNotes,
+    isLoadingStats,
+    isLoadingAchievements,
     profileError,
     fetchProfile,
     fetchPublicNotes,
+    fetchTastingStats,
+    fetchAchievements,
     clearProfile,
   } = useSocialStore();
 
@@ -26,9 +35,11 @@ export function PublicProfilePage() {
     if (userId) {
       clearProfile();
       fetchProfile(userId);
+      fetchTastingStats(userId);
+      fetchAchievements(userId);
       fetchPublicNotes(userId);
     }
-  }, [userId, fetchProfile, fetchPublicNotes, clearProfile]);
+  }, [userId, fetchProfile, fetchPublicNotes, fetchTastingStats, fetchAchievements, clearProfile]);
 
   const loadMoreNotes = () => {
     if (userId && notesPagination && notesPagination.page < notesPagination.totalPages) {
@@ -147,33 +158,160 @@ export function PublicProfilePage() {
           </CardContent>
         </Card>
 
-        {/* Public Tasting Notes */}
+        {/* Tabs */}
         {(!profile.isPrivate || isOwnProfile) && (
           <div>
-            <h2 className="text-xl font-bold text-zinc-100 mb-4">Public Tasting Notes</h2>
+            {/* Tab Navigation */}
+            <div className="flex border-b border-zinc-700 mb-6">
+              <button
+                onClick={() => setActiveTab('stats')}
+                className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                  activeTab === 'stats'
+                    ? 'border-amber-500 text-amber-500'
+                    : 'border-transparent text-zinc-400 hover:text-zinc-200'
+                }`}
+              >
+                Tasting Stats
+              </button>
+              <button
+                onClick={() => setActiveTab('achievements')}
+                className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                  activeTab === 'achievements'
+                    ? 'border-amber-500 text-amber-500'
+                    : 'border-transparent text-zinc-400 hover:text-zinc-200'
+                }`}
+              >
+                Achievements
+                {achievements && (
+                  <span className="ml-2 px-2 py-0.5 bg-zinc-700 rounded-full text-xs">
+                    {achievements.summary.earned}/{achievements.summary.total}
+                  </span>
+                )}
+              </button>
+              <button
+                onClick={() => setActiveTab('notes')}
+                className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                  activeTab === 'notes'
+                    ? 'border-amber-500 text-amber-500'
+                    : 'border-transparent text-zinc-400 hover:text-zinc-200'
+                }`}
+              >
+                Tasting Notes
+                {profile.stats.publicNotes > 0 && (
+                  <span className="ml-2 px-2 py-0.5 bg-zinc-700 rounded-full text-xs">
+                    {profile.stats.publicNotes}
+                  </span>
+                )}
+              </button>
+            </div>
 
-            {publicNotes.length === 0 && !isLoadingNotes ? (
-              <Card variant="outlined">
-                <CardContent className="text-center py-8">
-                  <p className="text-zinc-400">No public tasting notes yet.</p>
-                </CardContent>
-              </Card>
-            ) : (
-              <div className="space-y-4">
-                {publicNotes.map((note) => (
-                  <TastingNoteCard key={note.id} note={note} />
-                ))}
+            {/* Tab Content */}
+            {activeTab === 'stats' && (
+              <div>
+                {isLoadingStats ? (
+                  <div className="text-center py-8 text-zinc-400">Loading statistics...</div>
+                ) : tastingStats ? (
+                  <TastingStats stats={tastingStats} />
+                ) : (
+                  <Card variant="outlined">
+                    <CardContent className="text-center py-8">
+                      <p className="text-zinc-400">No tasting data yet.</p>
+                      <p className="text-sm text-zinc-500 mt-1">
+                        Complete a tasting session to see statistics.
+                      </p>
+                    </CardContent>
+                  </Card>
+                )}
+              </div>
+            )}
 
-                {/* Load More */}
-                {notesPagination && notesPagination.page < notesPagination.totalPages && (
-                  <div className="text-center pt-4">
-                    <Button
-                      variant="secondary"
-                      onClick={loadMoreNotes}
-                      disabled={isLoadingNotes}
-                    >
-                      {isLoadingNotes ? 'Loading...' : 'Load More'}
-                    </Button>
+            {activeTab === 'achievements' && (
+              <div>
+                {isLoadingAchievements ? (
+                  <div className="text-center py-8 text-zinc-400">Loading achievements...</div>
+                ) : achievements ? (
+                  <div>
+                    {/* Achievement Summary */}
+                    <Card variant="elevated" className="mb-6">
+                      <CardContent>
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <div className="text-2xl font-bold text-zinc-100">
+                              {achievements.summary.earned} / {achievements.summary.total}
+                            </div>
+                            <div className="text-sm text-zinc-400">Achievements Earned</div>
+                          </div>
+                          <div className="w-24 h-24 relative">
+                            <svg className="w-full h-full -rotate-90" viewBox="0 0 100 100">
+                              <circle
+                                cx="50"
+                                cy="50"
+                                r="40"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="8"
+                                className="text-zinc-700"
+                              />
+                              <circle
+                                cx="50"
+                                cy="50"
+                                r="40"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="8"
+                                strokeLinecap="round"
+                                className="text-amber-500"
+                                strokeDasharray={`${achievements.summary.percentage * 2.51} 251`}
+                              />
+                            </svg>
+                            <div className="absolute inset-0 flex items-center justify-center">
+                              <span className="text-xl font-bold text-amber-500">
+                                {achievements.summary.percentage}%
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </CardContent>
+                    </Card>
+
+                    <AchievementsGrid achievements={achievements.achievements} />
+                  </div>
+                ) : (
+                  <Card variant="outlined">
+                    <CardContent className="text-center py-8">
+                      <p className="text-zinc-400">Unable to load achievements.</p>
+                    </CardContent>
+                  </Card>
+                )}
+              </div>
+            )}
+
+            {activeTab === 'notes' && (
+              <div>
+                {publicNotes.length === 0 && !isLoadingNotes ? (
+                  <Card variant="outlined">
+                    <CardContent className="text-center py-8">
+                      <p className="text-zinc-400">No public tasting notes yet.</p>
+                    </CardContent>
+                  </Card>
+                ) : (
+                  <div className="space-y-4">
+                    {publicNotes.map((note) => (
+                      <TastingNoteCard key={note.id} note={note} />
+                    ))}
+
+                    {/* Load More */}
+                    {notesPagination && notesPagination.page < notesPagination.totalPages && (
+                      <div className="text-center pt-4">
+                        <Button
+                          variant="secondary"
+                          onClick={loadMoreNotes}
+                          disabled={isLoadingNotes}
+                        >
+                          {isLoadingNotes ? 'Loading...' : 'Load More'}
+                        </Button>
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -372,6 +372,53 @@ export interface ShareableScoreResponse {
   lockedAt: string;
 }
 
+// Tasting Stats Types
+export interface TastingStatsResponse {
+  overview: {
+    sessionsAttended: number;
+    whiskeysRated: number;
+    categoriesExplored: string[];
+  };
+  scoringTendencies: {
+    averages: {
+      nose: number;
+      palate: number;
+      finish: number;
+      overall: number;
+      total: number;
+    };
+    distribution: Record<number, number>;
+    tendency: 'generous' | 'balanced' | 'critical';
+  };
+  favoriteNotes: Array<{ term: string; count: number }>;
+  recentActivity: Array<{
+    id: string;
+    name: string;
+    theme: string;
+    completedAt: string;
+  }>;
+}
+
+export interface Achievement {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  category: string;
+  earned: boolean;
+  progress: number;
+  target: number;
+}
+
+export interface AchievementsResponse {
+  achievements: Achievement[];
+  summary: {
+    earned: number;
+    total: number;
+    percentage: number;
+  };
+}
+
 export const socialApi = {
   // Follow system
   follow: (userId: string) =>
@@ -402,6 +449,13 @@ export const socialApi = {
   // Public notes
   getPublicNotes: (userId: string, page = 1, limit = 10) =>
     request<PublicNotesResponse>(`/social/profile/${userId}/notes?page=${page}&limit=${limit}`),
+
+  // Tasting stats
+  getTastingStats: (userId: string) =>
+    request<TastingStatsResponse>(`/social/profile/${userId}/stats`),
+
+  getAchievements: (userId: string) =>
+    request<AchievementsResponse>(`/social/profile/${userId}/achievements`),
 
   // Score visibility
   toggleScoreVisibility: (scoreId: string, isPublic: boolean) =>

--- a/src/store/socialStore.ts
+++ b/src/store/socialStore.ts
@@ -90,6 +90,52 @@ interface ShareableScoreResponse {
   lockedAt: string;
 }
 
+interface TastingStatsResponse {
+  overview: {
+    sessionsAttended: number;
+    whiskeysRated: number;
+    categoriesExplored: string[];
+  };
+  scoringTendencies: {
+    averages: {
+      nose: number;
+      palate: number;
+      finish: number;
+      overall: number;
+      total: number;
+    };
+    distribution: Record<number, number>;
+    tendency: 'generous' | 'balanced' | 'critical';
+  };
+  favoriteNotes: Array<{ term: string; count: number }>;
+  recentActivity: Array<{
+    id: string;
+    name: string;
+    theme: string;
+    completedAt: string;
+  }>;
+}
+
+interface Achievement {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  category: string;
+  earned: boolean;
+  progress: number;
+  target: number;
+}
+
+interface AchievementsResponse {
+  achievements: Achievement[];
+  summary: {
+    earned: number;
+    total: number;
+    percentage: number;
+  };
+}
+
 interface SocialState {
   // Profile state
   profile: PublicProfileResponse | null;
@@ -113,6 +159,14 @@ interface SocialState {
   shareableScores: ShareableScoreResponse[];
   isLoadingShareable: boolean;
 
+  // Tasting stats state
+  tastingStats: TastingStatsResponse | null;
+  isLoadingStats: boolean;
+
+  // Achievements state
+  achievements: AchievementsResponse | null;
+  isLoadingAchievements: boolean;
+
   // Follow action state
   isFollowLoading: boolean;
 
@@ -122,6 +176,8 @@ interface SocialState {
   fetchFollowing: (userId: string, page?: number) => Promise<void>;
   fetchPublicNotes: (userId: string, page?: number) => Promise<void>;
   fetchShareableScores: () => Promise<void>;
+  fetchTastingStats: (userId: string) => Promise<void>;
+  fetchAchievements: (userId: string) => Promise<void>;
   followUser: (userId: string) => Promise<void>;
   unfollowUser: (userId: string) => Promise<void>;
   togglePrivacy: (isPublic: boolean) => Promise<void>;
@@ -151,6 +207,12 @@ export const useSocialStore = create<SocialState>()(
 
       shareableScores: [],
       isLoadingShareable: false,
+
+      tastingStats: null,
+      isLoadingStats: false,
+
+      achievements: null,
+      isLoadingAchievements: false,
 
       isFollowLoading: false,
 
@@ -239,6 +301,28 @@ export const useSocialStore = create<SocialState>()(
         } catch (error) {
           console.error('Failed to fetch shareable scores:', error);
           set({ isLoadingShareable: false });
+        }
+      },
+
+      fetchTastingStats: async (userId: string) => {
+        set({ isLoadingStats: true });
+        try {
+          const stats = await socialApi.getTastingStats(userId);
+          set({ tastingStats: stats, isLoadingStats: false });
+        } catch (error) {
+          console.error('Failed to fetch tasting stats:', error);
+          set({ isLoadingStats: false });
+        }
+      },
+
+      fetchAchievements: async (userId: string) => {
+        set({ isLoadingAchievements: true });
+        try {
+          const achievements = await socialApi.getAchievements(userId);
+          set({ achievements, isLoadingAchievements: false });
+        } catch (error) {
+          console.error('Failed to fetch achievements:', error);
+          set({ isLoadingAchievements: false });
         }
       },
 
@@ -353,6 +437,8 @@ export const useSocialStore = create<SocialState>()(
           followersPagination: null,
           followingPagination: null,
           notesPagination: null,
+          tastingStats: null,
+          achievements: null,
         });
       },
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive user profile functionality, social features, and tasting statistics to the whiskey tasting app.

### User Profile Features
- Profile page (`/profile`) for managing account settings
- Change display name, email, and password
- Profile photo upload (JPEG, PNG, GIF, WebP up to 5MB)
- Tasting profile with bio, favorite whiskey category, and experience level

### Social Features
- Follow/unfollow other users
- View followers and following lists with pagination
- Public profile pages (`/user/:userId`)
- Profile privacy toggle (public/private profiles)
- Shareable tasting notes - make individual scores public on your profile

### Tasting Statistics
- Sessions attended and whiskeys rated counts
- Categories explored visualization
- Score distribution chart
- Scoring tendency analysis (generous/balanced/critical)
- Average scores by category (nose, palate, finish, overall)
- Frequently used tasting notes word cloud
- Recent session activity

### Achievements/Badges
- 13 achievements across 4 categories:
  - **Sessions**: First Sip, Regular, Connoisseur
  - **Whiskeys**: Taster, Explorer, Collector, Library
  - **Exploration**: Regional Expert, World Traveler, Globe Trotter
  - **Hosting**: First Host, Party Planner, Master Host
- Progress tracking for unearned achievements
- Visual badges with category-specific icons

### Database Changes
- New `follows` table for follow relationships
- `is_profile_public` column on users (default: true)
- `is_public` column on scores (default: false)

### New API Endpoints
- `POST/DELETE /api/social/follow/:userId` - Follow/unfollow
- `GET /api/social/followers/:userId` - Paginated followers list
- `GET /api/social/following/:userId` - Paginated following list
- `GET /api/social/profile/:userId` - Public profile
- `PATCH /api/social/profile/privacy` - Toggle privacy
- `GET /api/social/profile/:userId/notes` - Public tasting notes
- `GET /api/social/profile/:userId/stats` - Tasting statistics
- `GET /api/social/profile/:userId/achievements` - Achievements
- `PATCH /api/scores/:scoreId/visibility` - Toggle note visibility

## Test plan
- [ ] Create account and verify profile page loads
- [ ] Upload profile photo and verify it displays in header
- [ ] Update tasting profile (bio, category, experience)
- [ ] Navigate to another user's public profile
- [ ] Follow/unfollow a user and verify counts update
- [ ] View followers and following lists
- [ ] Toggle profile privacy and verify restricted view
- [ ] Complete a tasting session
- [ ] Share a tasting note to public profile
- [ ] View tasting statistics on profile
- [ ] View achievements and progress tracking

🤖 Generated with [Claude Code](https://claude.ai/code)