### PR TITLE
Fix moderator detection and participant reveal view

### DIFF
--- a/src/pages/Reveal.tsx
+++ b/src/pages/Reveal.tsx
@@ -40,6 +40,13 @@ export function RevealPage() {
     }
   }, [sessionId, fetchSession, fetchResults]);
 
+  // Auto-reveal all results for non-moderators
+  useEffect(() => {
+    if (!isModerator && results?.results && results.results.length > 0 && revealedCount === 0) {
+      setRevealedCount(results.results.length);
+    }
+  }, [isModerator, results, revealedCount]);
+
   if (!session) {
     return (
       <div className="flex-1 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- Fix issue where host controls were not showing for session creators
- Fix issue where participants could not see reveal results

## Changes
- **server/src/routes/sessions.ts** - Use static JWT import instead of dynamic import for reliable token verification
- **src/pages/Reveal.tsx** - Auto-reveal all results for non-moderator participants

## Root Cause
The GET session endpoint was using dynamic `await import('jsonwebtoken')` which may not resolve correctly. Changed to static import like the rest of the codebase.

For the reveal page, `revealedCount` state was local to each browser and not synced - participants started at 0 and couldn't click reveal buttons.

## Test plan
- [ ] Create a session as host - verify host controls appear
- [ ] Join session as participant - verify participant view works
- [ ] Complete tasting and reveal - verify host can do dramatic reveal
- [ ] Verify participants see all results automatically on reveal page