### PR TITLE
Fix TypeScript build error in server sessions route

### DIFF
--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -260,7 +260,7 @@ router.post('/join', async (req: AuthRequest, res: Response) => {
     const isModerator = userId && session.moderatorId === userId;
 
     // Check if moderator already has a participant record
-    if (isModerator) {
+    if (isModerator && userId) {
       const existingParticipant = await db.query.participants.findFirst({
         where: and(
           eq(schema.participants.sessionId, session.id),


### PR DESCRIPTION
Add explicit userId null check to satisfy TypeScript's type narrowing for Drizzle ORM eq() function when querying participants by userId.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>