### PR TITLE
Fix ES module imports for Node.js production deployment

### DIFF
--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
-import * as schema from './schema';
+import * as schema from './schema.js';
 import path from 'path';
 
 const dbPath = process.env.DATABASE_PATH || path.join(process.cwd(), 'data', 'whiskey.db');

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,14 +5,14 @@ import { createServer } from 'http';
 import path from 'path';
 import dotenv from 'dotenv';
 
-import { initializeDatabase } from './db';
-import { initializeSocket } from './socket';
-import authRoutes from './routes/auth';
-import sessionsRoutes from './routes/sessions';
-import scoresRoutes from './routes/scores';
-import participantsRoutes from './routes/participants';
-import adminRoutes from './routes/admin';
-import socialRoutes from './routes/social';
+import { initializeDatabase } from './db/index.js';
+import { initializeSocket } from './socket/index.js';
+import authRoutes from './routes/auth.js';
+import sessionsRoutes from './routes/sessions.js';
+import scoresRoutes from './routes/scores.js';
+import participantsRoutes from './routes/participants.js';
+import adminRoutes from './routes/admin.js';
+import socialRoutes from './routes/social.js';
 
 // Load environment variables
 dotenv.config();

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
-import type { UserRole } from '../db/schema';
+import type { UserRole } from '../db/schema.js';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'whiskey-canon-secret-change-in-production';
 

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1,7 +1,7 @@
 import { Router, Response } from 'express';
-import { db, schema } from '../db';
+import { db, schema } from '../db/index.js';
 import { eq } from 'drizzle-orm';
-import { AuthRequest, authenticateUser, requireAdmin } from '../middleware/auth';
+import { AuthRequest, authenticateUser, requireAdmin } from '../middleware/auth.js';
 
 const router = Router();
 

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
-import { db, schema } from '../db';
+import { db, schema } from '../db/index.js';
 import { eq } from 'drizzle-orm';
 import {
   AuthRequest,
@@ -13,8 +13,8 @@ import {
   authenticateUser,
   verifyToken,
   JwtPayload,
-} from '../middleware/auth';
-import { validateEmail, normalizeEmail } from '../utils/validation';
+} from '../middleware/auth.js';
+import { validateEmail, normalizeEmail } from '../utils/validation.js';
 
 const router = Router();
 

--- a/server/src/routes/participants.ts
+++ b/server/src/routes/participants.ts
@@ -1,8 +1,8 @@
 import { Router, Response } from 'express';
-import { db, schema } from '../db';
+import { db, schema } from '../db/index.js';
 import { eq } from 'drizzle-orm';
-import { AuthRequest, authenticateParticipant } from '../middleware/auth';
-import { getIO } from '../socket';
+import { AuthRequest, authenticateParticipant } from '../middleware/auth.js';
+import { getIO } from '../socket/index.js';
 
 const router = Router();
 

--- a/server/src/routes/scores.ts
+++ b/server/src/routes/scores.ts
@@ -1,9 +1,9 @@
 import { Router, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
-import { db, schema } from '../db';
+import { db, schema } from '../db/index.js';
 import { eq, and } from 'drizzle-orm';
-import { AuthRequest, authenticateParticipant, authenticateUser } from '../middleware/auth';
-import { getIO } from '../socket';
+import { AuthRequest, authenticateParticipant, authenticateUser } from '../middleware/auth.js';
+import { getIO } from '../socket/index.js';
 
 const router = Router();
 

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -1,7 +1,7 @@
 import { Router, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import jwt from 'jsonwebtoken';
-import { db, schema } from '../db';
+import { db, schema } from '../db/index.js';
 import { eq, and } from 'drizzle-orm';
 import {
   AuthRequest,
@@ -9,8 +9,8 @@ import {
   authenticateParticipant,
   authenticateAny,
   generateParticipantToken,
-} from '../middleware/auth';
-import { getIO } from '../socket';
+} from '../middleware/auth.js';
+import { getIO } from '../socket/index.js';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'whiskey-canon-secret-change-in-production';
 

--- a/server/src/routes/social.ts
+++ b/server/src/routes/social.ts
@@ -1,8 +1,8 @@
 import { Router, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
-import { db, schema } from '../db';
+import { db, schema } from '../db/index.js';
 import { eq, and, desc, sql } from 'drizzle-orm';
-import { AuthRequest, authenticateUser } from '../middleware/auth';
+import { AuthRequest, authenticateUser } from '../middleware/auth.js';
 
 const router = Router();
 

--- a/server/src/socket/index.ts
+++ b/server/src/socket/index.ts
@@ -1,7 +1,7 @@
 import { Server as HttpServer } from 'http';
 import { Server, Socket } from 'socket.io';
-import { verifyToken, ParticipantJwtPayload, JwtPayload } from '../middleware/auth';
-import { db, schema } from '../db';
+import { verifyToken, ParticipantJwtPayload, JwtPayload } from '../middleware/auth.js';
+import { db, schema } from '../db/index.js';
 import { eq } from 'drizzle-orm';
 
 let io: Server;

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
Update all relative imports to include .js extensions and change moduleResolution from 'bundler' to 'node' to ensure compatibility with Node.js ES modules runtime. This resolves ERR_UNSUPPORTED_DIR_IMPORT errors when running the compiled server.