### PR TITLE
Use NodeNext module resolution to preserve .js extensions

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
Change TypeScript module settings to NodeNext which properly preserves .js extensions in compiled ES module imports for Node.js runtime compatibility.