### PR TITLE
Add database migrations for missing user profile columns

### DIFF
--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -120,6 +120,36 @@ export function initializeDatabase() {
 
   // Add new columns to existing tables (safe to run multiple times)
   try {
+    sqlite.exec(`ALTER TABLE users ADD COLUMN avatar_url TEXT;`);
+  } catch {
+    // Column already exists
+  }
+
+  try {
+    sqlite.exec(`ALTER TABLE users ADD COLUMN bio TEXT;`);
+  } catch {
+    // Column already exists
+  }
+
+  try {
+    sqlite.exec(`ALTER TABLE users ADD COLUMN favorite_category TEXT;`);
+  } catch {
+    // Column already exists
+  }
+
+  try {
+    sqlite.exec(`ALTER TABLE users ADD COLUMN experience_level TEXT;`);
+  } catch {
+    // Column already exists
+  }
+
+  try {
+    sqlite.exec(`ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'user';`);
+  } catch {
+    // Column already exists
+  }
+
+  try {
     sqlite.exec(`ALTER TABLE users ADD COLUMN is_profile_public INTEGER NOT NULL DEFAULT 1;`);
   } catch {
     // Column already exists


### PR DESCRIPTION
Add ALTER TABLE statements to create avatar_url, bio, favorite_category, experience_level, and role columns in existing users tables. This fixes SqliteError when registering new users on production databases.