### PR TITLE
Fix mixed content error by using relative URLs in production

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,4 +1,4 @@
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001/api';
+const API_BASE_URL = import.meta.env.VITE_API_URL || (import.meta.env.DEV ? 'http://localhost:3001/api' : '/api');
 
 interface RequestOptions extends RequestInit {
   skipAuth?: boolean;

--- a/src/services/socket.ts
+++ b/src/services/socket.ts
@@ -1,6 +1,6 @@
 import { io, Socket } from 'socket.io-client';
 
-const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || 'http://localhost:3001';
+const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || (import.meta.env.DEV ? 'http://localhost:3001' : window.location.origin);
 
 let socket: Socket | null = null;
 


### PR DESCRIPTION
Use relative URLs (/api) and window.location.origin for API and WebSocket connections in production instead of hardcoded http:// URLs. This ensures HTTPS is used when the site is served over HTTPS.