### PR TITLE
Update git commit guidelines in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ When committing changes:
   - Reference any relevant context (e.g., feature additions, bug fixes, refactors)
 
 When creating Pull Requests (on branches other than main):
-- Generate a comprehensive PR description covering all changes since branching from main
+- Only include changes since the last PR (not cumulative changes since branching)
 - Use a short summary line (50 chars or less) as the PR title
 - Include detailed bullet points describing each change in the PR body
 - Group related changes together


### PR DESCRIPTION
## Summary

Updates to the Git Commit Guidelines documentation.

- Clarify that AI attribution/co-author tags should not be included in commit messages or PRs
- Specify that PR descriptions should only cover changes since the last PR, not cumulative changes since branching

## Test Plan
- [ ] Review CLAUDE.md for clarity