### PR TITLE
Add email verification with Resend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ This is a full-stack blind whiskey tasting application with real-time synchroniz
 ### Frontend (React 19 + TypeScript)
 
 **State Management**: Zustand stores in `src/store/`
+
 - `authStore.ts` - User authentication state, persisted to localStorage
 - `sessionStore.ts` - Tasting session state, WebSocket event handlers
 
@@ -45,6 +46,7 @@ This is a full-stack blind whiskey tasting application with real-time synchroniz
 **Database**: SQLite via Drizzle ORM. Schema in `server/src/db/schema.ts`. Tables: users, sessions, whiskeys, participants, scores, refreshTokens.
 
 **Authentication**: Three token types in `server/src/middleware/auth.ts`:
+
 - Access token (JWT) - Registered user authentication
 - Refresh token - Token renewal
 - Participant token - Guest participant authentication for sessions
@@ -52,6 +54,7 @@ This is a full-stack blind whiskey tasting application with real-time synchroniz
 **Real-time**: Socket.io in `server/src/socket/index.ts`. Participants join session rooms; events broadcast phase changes, scores, and status updates.
 
 **Routes**:
+
 - `/api/auth/*` - Authentication (register, login, profile updates, avatar upload)
 - `/api/sessions/*` - Session CRUD, join, start, advance phase, reveal
 - `/api/scores/*` - Score submission
@@ -68,6 +71,7 @@ This is a full-stack blind whiskey tasting application with real-time synchroniz
 ### Database Changes
 
 When adding columns to existing tables, run ALTER TABLE directly on `data/whiskey.db`:
+
 ```bash
 sqlite3 data/whiskey.db "ALTER TABLE table_name ADD COLUMN column_name TYPE;"
 ```
@@ -79,6 +83,7 @@ Avatar uploads stored in `uploads/avatars/`. Multer configured in `server/src/ro
 ## Git Commit Guidelines
 
 When committing changes:
+
 - Do not include any AI attribution or co-author tags in commit messages or PRs
 - Use `fusion94@gmail.com` for commit author attribution
 - Use `git add .` to stage all changes
@@ -89,6 +94,7 @@ When committing changes:
   - Reference any relevant context (e.g., feature additions, bug fixes, refactors)
 
 When creating Pull Requests (on branches other than main):
+
 - Only include changes since the last PR (not cumulative changes since branching)
 - Use a short summary line (50 chars or less) as the PR title
 - Include detailed bullet points describing each change in the PR body

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-dom": "^19.2.0",
         "react-hook-form": "^7.71.1",
         "react-router-dom": "^7.13.0",
+        "resend": "^6.9.1",
         "socket.io": "^4.8.3",
         "socket.io-client": "^4.8.3",
         "uuid": "^13.0.0",
@@ -1439,10 +1440,29 @@
         "win32"
       ]
     },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -2260,6 +2280,17 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@zone-eu/mailsplit": {
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz",
+      "integrity": "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA==",
+      "license": "(MIT OR EUPL-1.1+)",
+      "dependencies": {
+        "libbase64": "1.3.0",
+        "libmime": "5.3.7",
+        "libqp": "2.1.1"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -2904,6 +2935,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2920,6 +2960,61 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -3127,6 +3222,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding-japanese": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
+      "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -3242,6 +3346,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -3642,6 +3758,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -3941,6 +4063,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -3956,6 +4087,41 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
       }
     },
     "node_modules/http-errors": {
@@ -4260,6 +4426,15 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4273,6 +4448,42 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libbase64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.3.0.tgz",
+      "integrity": "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==",
+      "license": "MIT"
+    },
+    "node_modules/libmime": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.7.tgz",
+      "integrity": "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw==",
+      "license": "MIT",
+      "dependencies": {
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.6.3",
+        "libbase64": "1.3.0",
+        "libqp": "2.1.1"
+      }
+    },
+    "node_modules/libmime/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/libqp": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/libqp/-/libqp-2.1.1.tgz",
+      "integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==",
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.30.2",
@@ -4535,6 +4746,15 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4618,6 +4838,40 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mailparser": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.1.tgz",
+      "integrity": "sha512-6vHZcco3fWsDMkf4Vz9iAfxvwrKNGbHx0dV1RKVphQ/zaNY34Buc7D37LSa09jeSeybWzYcTPjhiZFxzVRJedA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zone-eu/mailsplit": "5.4.8",
+        "encoding-japanese": "2.2.0",
+        "he": "1.2.0",
+        "html-to-text": "9.0.5",
+        "iconv-lite": "0.7.0",
+        "libmime": "5.3.7",
+        "linkify-it": "5.0.0",
+        "nodemailer": "7.0.11",
+        "punycode.js": "2.3.1",
+        "tlds": "1.261.0"
+      }
+    },
+    "node_modules/mailparser/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4866,6 +5120,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nodemailer": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.11.tgz",
+      "integrity": "sha512-gnXhNRE0FNhD7wPSCGhdNh46Hs6nm+uTyg+Kq0cZukNQiYdnCsoQjodNP9BQVG9XrcK/v6/MgpAPBUFyzh9pvw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4971,6 +5234,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -5008,6 +5284,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/picocolors": {
@@ -5123,6 +5408,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5300,6 +5594,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resend": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.9.1.tgz",
+      "integrity": "sha512-jFY3qPP2cith1npRXvS7PVdnhbR1CcuzHg65ty5Elv55GKiXhe+nItXuzzoOlKeYJez1iJAo2+8f6ae8sCj0iA==",
+      "license": "MIT",
+      "dependencies": {
+        "mailparser": "3.9.1",
+        "svix": "1.84.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5422,6 +5737,18 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -5773,6 +6100,16 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -5853,6 +6190,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/svix": {
+      "version": "1.84.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.84.1.tgz",
+      "integrity": "sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/svix/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
@@ -5917,6 +6277,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tlds": {
+      "version": "1.261.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
+      "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
+      "license": "MIT",
+      "bin": {
+        "tlds": "bin.js"
       }
     },
     "node_modules/toidentifier": {
@@ -6060,6 +6429,12 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.71.1",
     "react-router-dom": "^7.13.0",
+    "resend": "^6.9.1",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3",
     "uuid": "^13.0.0",

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -161,6 +161,25 @@ export function initializeDatabase() {
     // Column already exists
   }
 
+  // Email verification columns
+  try {
+    sqlite.exec(`ALTER TABLE users ADD COLUMN email_verified INTEGER NOT NULL DEFAULT 0;`);
+  } catch {
+    // Column already exists
+  }
+
+  try {
+    sqlite.exec(`ALTER TABLE users ADD COLUMN verification_code TEXT;`);
+  } catch {
+    // Column already exists
+  }
+
+  try {
+    sqlite.exec(`ALTER TABLE users ADD COLUMN verification_code_expires_at INTEGER;`);
+  } catch {
+    // Column already exists
+  }
+
   console.log('Database initialized');
 }
 

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -21,6 +21,9 @@ export const users = sqliteTable('users', {
   experienceLevel: text('experience_level'), // Tasting experience level
   role: text('role').notNull().default('user'), // 'user' or 'admin'
   isProfilePublic: integer('is_profile_public', { mode: 'boolean' }).notNull().default(true), // Privacy toggle
+  emailVerified: integer('email_verified', { mode: 'boolean' }).notNull().default(false), // Email verification status
+  verificationCode: text('verification_code'), // 6-digit verification code
+  verificationCodeExpiresAt: integer('verification_code_expires_at', { mode: 'timestamp' }), // Code expiration
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
 });
 

--- a/server/src/services/email.ts
+++ b/server/src/services/email.ts
@@ -1,0 +1,85 @@
+import { Resend } from 'resend';
+
+const APP_NAME = 'Whiskey Canon';
+
+// Lazy-initialize Resend client to ensure env vars are loaded
+let resendClient: Resend | null = null;
+function getResendClient(): Resend | null {
+  if (resendClient) return resendClient;
+  if (process.env.RESEND_API_KEY) {
+    resendClient = new Resend(process.env.RESEND_API_KEY);
+    console.log('[Email] Resend client initialized');
+  }
+  return resendClient;
+}
+
+function getFromEmail(): string {
+  return process.env.FROM_EMAIL || 'Whiskey Canon <onboarding@resend.dev>';
+}
+
+// Generate a 6-digit verification code
+export function generateVerificationCode(): string {
+  return Math.floor(100000 + Math.random() * 900000).toString();
+}
+
+// Code expires in 15 minutes
+export function getCodeExpiration(): Date {
+  return new Date(Date.now() + 15 * 60 * 1000);
+}
+
+export interface SendVerificationEmailResult {
+  success: boolean;
+  error?: string;
+  devCode?: string; // Only returned in development mode without API key
+}
+
+export async function sendVerificationEmail(
+  email: string,
+  code: string,
+  displayName: string
+): Promise<SendVerificationEmailResult> {
+  const resend = getResendClient();
+
+  // Without API key, log the code (dev mode)
+  if (!resend) {
+    console.log('===========================================');
+    console.log(`[DEV MODE] Verification code for ${email}: ${code}`);
+    console.log('===========================================');
+    return { success: true, devCode: code };
+  }
+
+  try {
+    console.log(`[Email] Sending verification email to ${email}`);
+    const result = await resend.emails.send({
+      from: getFromEmail(),
+      to: email,
+      subject: `${APP_NAME} - Verify your email`,
+      html: `
+        <div style="font-family: system-ui, -apple-system, sans-serif; max-width: 600px; margin: 0 auto; padding: 40px 20px;">
+          <h1 style="color: #d97706; margin-bottom: 24px;">Welcome to ${APP_NAME}</h1>
+          <p style="color: #374151; font-size: 16px; line-height: 1.6;">
+            Hi ${displayName},
+          </p>
+          <p style="color: #374151; font-size: 16px; line-height: 1.6;">
+            Thanks for signing up! Please use the following verification code to complete your registration:
+          </p>
+          <div style="background: #f3f4f6; border-radius: 8px; padding: 24px; text-align: center; margin: 24px 0;">
+            <span style="font-size: 32px; font-weight: bold; letter-spacing: 4px; color: #1f2937;">${code}</span>
+          </div>
+          <p style="color: #6b7280; font-size: 14px;">
+            This code will expire in 15 minutes. If you didn't create an account, you can safely ignore this email.
+          </p>
+          <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 32px 0;" />
+          <p style="color: #9ca3af; font-size: 12px; text-align: center;">
+            ${APP_NAME} - Blind whiskey tasting made simple
+          </p>
+        </div>
+      `,
+    });
+    console.log(`[Email] Sent successfully:`, result);
+    return { success: true };
+  } catch (error) {
+    console.error('[Email] Failed to send verification email:', error);
+    return { success: false, error: 'Failed to send verification email' };
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
   RevealPage,
   LoginPage,
   RegisterPage,
+  VerifyEmailPage,
   LogoutPage,
   AdminPage,
   ProfilePage,
@@ -36,6 +37,7 @@ function App() {
           {/* Auth */}
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
+          <Route path="/verify-email" element={<VerifyEmailPage />} />
           <Route path="/logout" element={<LogoutPage />} />
           <Route path="/profile" element={<ProfilePage />} />
 

--- a/src/pages/VerifyEmail.tsx
+++ b/src/pages/VerifyEmail.tsx
@@ -1,0 +1,212 @@
+import { useState, useEffect, useRef } from 'react';
+import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { Button, Card, CardContent } from '@/components/ui';
+import { useAuthStore } from '@/store/authStore';
+import { authApi } from '@/services/api';
+
+export function VerifyEmailPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { setUser } = useAuthStore();
+
+  const email = location.state?.email || '';
+  const devCode = location.state?.devCode;
+
+  const [code, setCode] = useState(['', '', '', '', '', '']);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [resendCooldown, setResendCooldown] = useState(0);
+  const [newDevCode, setNewDevCode] = useState<string | null>(null);
+
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+  // Redirect if no email, or auto-send verification if coming from login (no devCode means no recent registration)
+  useEffect(() => {
+    if (!email) {
+      navigate('/register');
+      return;
+    }
+    // Auto-send verification email if we don't have a devCode (coming from login, not registration)
+    if (!devCode && resendCooldown === 0) {
+      handleResend();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [email, navigate]);
+
+  // Resend cooldown timer
+  useEffect(() => {
+    if (resendCooldown > 0) {
+      const timer = setTimeout(() => setResendCooldown(resendCooldown - 1), 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [resendCooldown]);
+
+  const handleInputChange = (index: number, value: string) => {
+    if (!/^\d*$/.test(value)) return;
+
+    const newCode = [...code];
+    newCode[index] = value.slice(-1);
+    setCode(newCode);
+
+    // Auto-focus next input
+    if (value && index < 5) {
+      inputRefs.current[index + 1]?.focus();
+    }
+  };
+
+  const handleKeyDown = (index: number, e: React.KeyboardEvent) => {
+    if (e.key === 'Backspace' && !code[index] && index > 0) {
+      inputRefs.current[index - 1]?.focus();
+    }
+  };
+
+  const handlePaste = (e: React.ClipboardEvent) => {
+    e.preventDefault();
+    const pasted = e.clipboardData.getData('text').replace(/\D/g, '').slice(0, 6);
+    const newCode = [...code];
+    for (let i = 0; i < pasted.length; i++) {
+      newCode[i] = pasted[i];
+    }
+    setCode(newCode);
+    inputRefs.current[Math.min(pasted.length, 5)]?.focus();
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const fullCode = code.join('');
+
+    if (fullCode.length !== 6) {
+      setError('Please enter all 6 digits');
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await authApi.verifyEmail({ email, code: fullCode });
+      localStorage.setItem('accessToken', response.accessToken);
+      setUser({
+        id: response.user.id,
+        email: response.user.email,
+        displayName: response.user.displayName,
+        role: response.user.role,
+      });
+      navigate('/');
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleResend = async () => {
+    console.log('[VerifyEmail] handleResend called, email:', email, 'cooldown:', resendCooldown);
+    if (resendCooldown > 0) return;
+    if (!email) {
+      console.log('[VerifyEmail] No email, skipping resend');
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    setNewDevCode(null);
+
+    try {
+      console.log('[VerifyEmail] Calling resendVerification API');
+      const response = await authApi.resendVerification({ email });
+      setResendCooldown(60);
+      if (response.devCode) {
+        setNewDevCode(response.devCode);
+      }
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const displayCode = newDevCode || devCode;
+
+  return (
+    <div className="flex-1 flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-zinc-100">Verify Your Email</h1>
+          <p className="text-zinc-400 mt-2">
+            We sent a 6-digit code to <span className="text-amber-500">{email}</span>
+          </p>
+        </div>
+
+        <Card variant="elevated">
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-6">
+              {/* Development mode helper */}
+              {displayCode && (
+                <div className="p-3 bg-blue-500/10 border border-blue-500/30 rounded-lg">
+                  <p className="text-sm text-blue-400">
+                    Dev mode - Code: <span className="font-mono font-bold">{displayCode}</span>
+                  </p>
+                </div>
+              )}
+
+              {/* 6-digit code input */}
+              <div className="flex justify-center gap-2" onPaste={handlePaste}>
+                {code.map((digit, index) => (
+                  <input
+                    key={index}
+                    ref={(el) => { inputRefs.current[index] = el; }}
+                    type="text"
+                    inputMode="numeric"
+                    maxLength={1}
+                    value={digit}
+                    onChange={(e) => handleInputChange(index, e.target.value)}
+                    onKeyDown={(e) => handleKeyDown(index, e)}
+                    className="w-12 h-14 text-center text-2xl font-bold bg-zinc-800 border border-zinc-700 rounded-lg text-zinc-100 focus:border-amber-500 focus:ring-1 focus:ring-amber-500 outline-none"
+                    autoFocus={index === 0}
+                  />
+                ))}
+              </div>
+
+              {error && (
+                <div className="p-3 bg-red-500/10 border border-red-500/30 rounded-lg">
+                  <p className="text-sm text-red-400">{error}</p>
+                </div>
+              )}
+
+              <Button
+                type="submit"
+                variant="primary"
+                size="lg"
+                className="w-full"
+                isLoading={isLoading}
+              >
+                Verify Email
+              </Button>
+
+              <div className="text-center">
+                <p className="text-zinc-400 text-sm">
+                  Didn't receive the code?{' '}
+                  <button
+                    type="button"
+                    onClick={handleResend}
+                    disabled={resendCooldown > 0 || isLoading}
+                    className="text-amber-500 hover:text-amber-400 disabled:text-zinc-500 disabled:cursor-not-allowed"
+                  >
+                    {resendCooldown > 0 ? `Resend in ${resendCooldown}s` : 'Resend code'}
+                  </button>
+                </p>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+
+        <div className="mt-6 text-center">
+          <Link to="/register" className="text-zinc-500 hover:text-zinc-300 text-sm">
+            Back to Register
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -6,6 +6,7 @@ export { TastingSessionPage } from './TastingSession';
 export { RevealPage } from './Reveal';
 export { LoginPage } from './Login';
 export { RegisterPage } from './Register';
+export { VerifyEmailPage } from './VerifyEmail';
 export { LogoutPage } from './Logout';
 export { AdminPage } from './Admin';
 export { ProfilePage } from './Profile';

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -54,8 +54,28 @@ export type UserRole = 'user' | 'admin';
 
 export const authApi = {
   register: (data: { email: string; password: string; displayName: string }) =>
-    request<{ user: { id: string; email: string; displayName: string; role: UserRole }; accessToken: string }>(
+    request<{
+      message: string;
+      requiresVerification: boolean;
+      email: string;
+      devCode?: string;
+    }>(
       '/auth/register',
+      { method: 'POST', body: JSON.stringify(data) }
+    ),
+
+  verifyEmail: (data: { email: string; code: string }) =>
+    request<{
+      user: { id: string; email: string; displayName: string; role: UserRole };
+      accessToken: string;
+    }>(
+      '/auth/verify-email',
+      { method: 'POST', body: JSON.stringify(data) }
+    ),
+
+  resendVerification: (data: { email: string }) =>
+    request<{ message: string; devCode?: string }>(
+      '/auth/resend-verification',
       { method: 'POST', body: JSON.stringify(data) }
     ),
 

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -45,26 +45,12 @@ export const useAuthStore = create<AuthState>()(
         isLoading: false,
         error: null,
 
-        register: async (email, password, displayName) => {
-          set({ isLoading: true, error: null });
-          try {
-            const response = await authApi.register({ email, password, displayName });
-            // Store access token for API requests
-            localStorage.setItem('accessToken', response.accessToken);
-            const user = { ...response.user, role: response.user.role || 'user' } as User;
-            set({
-              user,
-              isAuthenticated: true,
-              isAdmin: user.role === 'admin',
-              isLoading: false,
-            });
-          } catch (error) {
-            set({
-              error: (error as Error).message,
-              isLoading: false,
-            });
-            throw error;
-          }
+        // Note: register no longer authenticates - it returns verification info
+        // The actual authentication happens after email verification
+        register: async (_email, _password, _displayName) => {
+          // This method is deprecated - use authApi.register directly
+          // and navigate to /verify-email with the response
+          throw new Error('Use authApi.register directly and navigate to /verify-email');
         },
 
         login: async (email, password) => {
@@ -161,7 +147,11 @@ export const useAuthStore = create<AuthState>()(
 
         setLoading: (loading) => set({ isLoading: loading }),
 
-        setUser: (user) => set({ user }),
+        setUser: (user) => set({
+          user,
+          isAuthenticated: true,
+          isAdmin: user.role === 'admin',
+        }),
 
         clearError: () => set({ error: null }),
       }),


### PR DESCRIPTION
## Summary

Implements email verification for new user registration using Resend.

### Backend
- Add `emailVerified`, `verificationCode`, `verificationCodeExpiresAt` columns to users table
- Create email service with Resend integration (lazy-initialized for env var timing)
- Modify `/auth/register` to send 6-digit verification code instead of issuing tokens
- Add `/auth/verify-email` endpoint for code verification
- Add `/auth/resend-verification` endpoint
- Modify `/auth/login` to check email verification status (403 if unverified)

### Frontend
- Add VerifyEmail page with 6-digit code input (auto-focus, paste support)
- Auto-send verification email when redirected from login
- Update Register to navigate to `/verify-email` after submission
- Update Login to handle unverified users with redirect option

### Configuration
- Add `resend` package dependency
- Support `RESEND_API_KEY` and `FROM_EMAIL` environment variables
- Dev mode: codes logged to console when no API key set

## Test Plan
- [ ] Register new user - should receive verification email
- [ ] Enter correct code - should authenticate and redirect to home
- [ ] Enter wrong code - should show error
- [ ] Click resend - should send new code (60s cooldown)
- [ ] Login with unverified email - should show verification prompt
- [ ] Dev mode without API key - code shown in console and UI