### PR TITLE
Add file content validation and fix email normalization

### DIFF
--- a/SESSION_LOG.md
+++ b/SESSION_LOG.md
@@ -4,4 +4,6 @@
 
 **2026-01-30 15:45** - implement phase 2
 
+**2026-01-30 16:30** - implement the critical and high items
+
 ---


### PR DESCRIPTION
## Summary

- Add magic byte validation for uploaded avatar images to prevent malicious file uploads
- Fix email normalization consistency across all authentication endpoints

## Changes

### File Content Validation (HIGH-02)

Added `validateImageMagicBytes()` function that validates uploaded files by checking their magic byte signatures rather than trusting the MIME type from the request (which can be spoofed).

**Supported formats:**
| Format | Magic Bytes |
|--------|-------------|
| JPEG | `FF D8 FF` |
| PNG | `89 50 4E 47 0D 0A 1A 0A` |
| GIF | `47 49 46 38` (GIF8) |
| WebP | `52 49 46 46...57 45 42 50` (RIFF...WEBP) |

**Behavior:**
- Reads uploaded file and checks first bytes against known signatures
- Rejects files that don't match valid image signatures
- Automatically cleans up invalid uploads from disk
- Returns clear error message to user

### Email Normalization Fix (HIGH-03)

Fixed inconsistent email handling in the login endpoint:
- **Before:** `email.toLowerCase()` (only lowercase)
- **After:** `normalizeEmail(email)` (trim + lowercase)

This ensures consistent email normalization across all endpoints (register, login, verify, reset password, etc.).

## Files Changed

| File | Changes |
|------|---------|
| `server/src/utils/validation.ts` | Add `validateImageMagicBytes()` function |
| `server/src/routes/auth.ts` | Add file validation to avatar upload, fix email normalization |

## Test Plan

- [ ] Upload valid JPEG, PNG, GIF, WebP avatars - should succeed
- [ ] Upload a text file renamed to .jpg - should be rejected
- [ ] Upload a file with spoofed MIME type - should be rejected
- [ ] Login with email containing leading/trailing spaces - should work
- [ ] Verify all email lookups use consistent normalization