### PR TITLE
Disable rate limiting in development mode

### DIFF
--- a/server/src/middleware/rateLimit.ts
+++ b/server/src/middleware/rateLimit.ts
@@ -1,9 +1,14 @@
 import rateLimit from 'express-rate-limit';
 
+const isDevelopment = process.env.NODE_ENV !== 'production';
+
+// In development, use very high limits (effectively no limit)
+const devMax = 10000;
+
 // Auth endpoints (login, register, forgot-password): 5 requests/15 min per IP
 export const authLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 5,
+  max: isDevelopment ? devMax : 5,
   message: { error: 'Too many authentication attempts, please try again later' },
   standardHeaders: true,
   legacyHeaders: false,
@@ -12,7 +17,7 @@ export const authLimiter = rateLimit({
 // Verification endpoints (verify-email, reset-password): 10 requests/15 min per IP
 export const verificationLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 10,
+  max: isDevelopment ? devMax : 10,
   message: { error: 'Too many verification attempts, please try again later' },
   standardHeaders: true,
   legacyHeaders: false,
@@ -21,7 +26,7 @@ export const verificationLimiter = rateLimit({
 // Session join: 10 requests/min per IP
 export const sessionJoinLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
-  max: 10,
+  max: isDevelopment ? devMax : 10,
   message: { error: 'Too many join attempts, please try again later' },
   standardHeaders: true,
   legacyHeaders: false,
@@ -30,7 +35,7 @@ export const sessionJoinLimiter = rateLimit({
 // General API: 100 requests/min per IP
 export const generalLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
-  max: 100,
+  max: isDevelopment ? devMax : 100,
   message: { error: 'Too many requests, please try again later' },
   standardHeaders: true,
   legacyHeaders: false,
@@ -41,7 +46,7 @@ export const generalLimiter = rateLimit({
 // Stats/analytics endpoints: 2 requests/min per IP (CPU-intensive aggregations)
 export const statsLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
-  max: 2,
+  max: isDevelopment ? devMax : 2,
   message: { error: 'Too many stats requests, please try again later' },
   standardHeaders: true,
   legacyHeaders: false,
@@ -50,7 +55,7 @@ export const statsLimiter = rateLimit({
 // Data export endpoints: 1 request/min per IP (generates large responses)
 export const exportLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
-  max: 1,
+  max: isDevelopment ? devMax : 1,
   message: { error: 'Too many export requests, please try again later' },
   standardHeaders: true,
   legacyHeaders: false,
@@ -59,7 +64,7 @@ export const exportLimiter = rateLimit({
 // Session results endpoints: 5 requests/min per IP (complex scoring queries)
 export const resultsLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
-  max: 5,
+  max: isDevelopment ? devMax : 5,
   message: { error: 'Too many results requests, please try again later' },
   standardHeaders: true,
   legacyHeaders: false,


### PR DESCRIPTION
## Summary
- Disable rate limiting when NODE_ENV is not production
- Makes development and testing easier without hitting rate limit errors

## Changes
- Add `isDevelopment` check to all rate limiters in `server/src/middleware/rateLimit.ts`
- Use high limit (10000) in development, production limits unchanged

## Test plan
- [x] Verified login works without rate limit errors in development
- [ ] Verify rate limits still apply in production (NODE_ENV=production)