### PR TITLE
Add unit testing with Vitest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,4 @@ uploads/avatars/*
 *.sw?
 
 # TypeScript
-*.tsbuildinfo
+*.tsbuildinfocoverage/

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,8 @@
       "devDependencies": {
         "@eslint/js": "^9.39.1",
         "@tailwindcss/vite": "^4.1.18",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/bcryptjs": "^2.4.6",
         "@types/better-sqlite3": "^7.6.13",
         "@types/cookie-parser": "^1.4.10",
@@ -47,18 +49,90 @@
         "@types/react-dom": "^19.2.3",
         "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^5.1.1",
+        "@vitest/coverage-v8": "^4.0.18",
         "concurrently": "^9.2.1",
         "drizzle-kit": "^0.31.8",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "jsdom": "^27.4.0",
         "tailwindcss": "^4.1.18",
         "tsx": "^4.21.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
-        "vite": "^7.2.4"
+        "vite": "^7.2.4",
+        "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
+      "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
+      "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.28.6",
@@ -294,6 +368,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -340,6 +424,148 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
+      "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@drizzle-team/brocli": {
@@ -972,6 +1198,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.10.0.tgz",
+      "integrity": "sha512-tf8YdcbirXdPnJ+Nd4UN1EXnz+IP2DI45YVEr3vvzcVTOyrApkmIB4zvOQVd3XPr7RXnfBtAx+PXImXOIU0Ajg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
@@ -1468,6 +1712,13 @@
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
@@ -1746,6 +1997,90 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1819,6 +2154,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -1847,6 +2193,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2283,6 +2636,148 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
+      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.18",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.18",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@zone-eu/mailsplit": {
       "version": "5.4.8",
       "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz",
@@ -2328,6 +2823,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2385,6 +2890,45 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.10.tgz",
+      "integrity": "sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^9.0.1"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2453,6 +2997,16 @@
       },
       "engines": {
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bindings": {
@@ -2659,6 +3213,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2892,12 +3456,83 @@
         "http-errors": "^2.0.0"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2915,6 +3550,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -2965,6 +3607,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2973,6 +3625,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -3390,6 +4050,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3660,6 +4327,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3686,6 +4363,16 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -4128,6 +4815,26 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-to-text": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
@@ -4181,6 +4888,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -4256,6 +4991,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -4319,6 +5064,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -4331,6 +5083,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -4360,6 +5151,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -4878,6 +5709,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4886,6 +5728,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
+      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/mailparser": {
@@ -4922,6 +5776,35 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4930,6 +5813,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -4987,6 +5877,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -5198,6 +6098,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -5282,6 +6193,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/parseley": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
@@ -5333,6 +6270,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/peberminta": {
       "version": "0.9.0",
@@ -5426,6 +6370,36 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/proxy-addr": {
@@ -5570,6 +6544,14 @@
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -5632,10 +6614,34 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5779,6 +6785,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -5973,6 +6992,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -6148,6 +7174,13 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/standardwebhooks": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
@@ -6166,6 +7199,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -6207,6 +7247,19 @@
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -6261,6 +7314,13 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
@@ -6310,6 +7370,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6327,6 +7404,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tlds": {
       "version": "1.261.0",
       "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
@@ -6336,6 +7423,26 @@
         "tlds": "bin.js"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
+      "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.19"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
+      "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -6343,6 +7450,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -6643,6 +7776,131 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6657,6 +7915,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -6713,6 +7988,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "build:server": "tsc -p server/tsconfig.json",
     "start:server": "node server/dist/index.js",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -41,6 +44,8 @@
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.1.18",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/bcryptjs": "^2.4.6",
     "@types/better-sqlite3": "^7.6.13",
     "@types/cookie-parser": "^1.4.10",
@@ -53,17 +58,20 @@
     "@types/react-dom": "^19.2.3",
     "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^5.1.1",
+    "@vitest/coverage-v8": "^4.0.18",
     "concurrently": "^9.2.1",
     "drizzle-kit": "^0.31.8",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^27.4.0",
     "tailwindcss": "^4.1.18",
     "tsx": "^4.21.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "^7.2.4"
+    "vite": "^7.2.4",
+    "vitest": "^4.0.18"
   },
   "overrides": {
     "esbuild": "^0.25.0"

--- a/server/src/middleware/auth.test.ts
+++ b/server/src/middleware/auth.test.ts
@@ -1,0 +1,435 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import jwt from 'jsonwebtoken';
+import type { Response, NextFunction } from 'express';
+import {
+  getJwtSecret,
+  generateAccessToken,
+  generateRefreshToken,
+  generateParticipantToken,
+  verifyToken,
+  authenticateUser,
+  authenticateParticipant,
+  authenticateAny,
+  requireAdmin,
+  type AuthRequest,
+} from './auth.js';
+
+describe('getJwtSecret', () => {
+  const originalEnv = process.env.JWT_SECRET;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.JWT_SECRET = originalEnv;
+    } else {
+      delete process.env.JWT_SECRET;
+    }
+  });
+
+  it('should return JWT_SECRET when set', () => {
+    process.env.JWT_SECRET = 'test-secret-key';
+    expect(getJwtSecret()).toBe('test-secret-key');
+  });
+
+  it('should throw error when JWT_SECRET is not set', () => {
+    delete process.env.JWT_SECRET;
+    expect(() => getJwtSecret()).toThrow('JWT_SECRET environment variable is required but not set');
+  });
+});
+
+describe('generateAccessToken', () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = 'test-secret-for-tokens';
+  });
+
+  it('should generate a valid JWT token', () => {
+    const payload = { userId: 'user-123', email: 'test@example.com', role: 'user' as const };
+    const token = generateAccessToken(payload);
+
+    expect(token).toBeTruthy();
+    expect(typeof token).toBe('string');
+    expect(token.split('.')).toHaveLength(3); // JWT has 3 parts
+  });
+
+  it('should include payload in token', () => {
+    const payload = { userId: 'user-123', email: 'test@example.com', role: 'user' as const };
+    const token = generateAccessToken(payload);
+    const decoded = jwt.verify(token, 'test-secret-for-tokens') as typeof payload & { iat: number; exp: number };
+
+    expect(decoded.userId).toBe(payload.userId);
+    expect(decoded.email).toBe(payload.email);
+    expect(decoded.role).toBe(payload.role);
+  });
+
+  it('should have 15 minute expiration', () => {
+    const payload = { userId: 'user-123', email: 'test@example.com', role: 'user' as const };
+    const token = generateAccessToken(payload);
+    const decoded = jwt.verify(token, 'test-secret-for-tokens') as { iat: number; exp: number };
+
+    const expiresIn = decoded.exp - decoded.iat;
+    expect(expiresIn).toBe(15 * 60); // 15 minutes in seconds
+  });
+
+  it('should generate unique tokens', () => {
+    const payload = { userId: 'user-123', email: 'test@example.com', role: 'user' as const };
+
+    // Small delay to ensure different iat
+    const token1 = generateAccessToken(payload);
+    const token2 = generateAccessToken(payload);
+
+    // Tokens will be the same if generated at the same second, but should be valid
+    expect(token1).toBeTruthy();
+    expect(token2).toBeTruthy();
+  });
+});
+
+describe('generateRefreshToken', () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = 'test-secret-for-tokens';
+  });
+
+  it('should generate a valid JWT token', () => {
+    const payload = { userId: 'user-123', email: 'test@example.com', role: 'user' as const };
+    const token = generateRefreshToken(payload);
+
+    expect(token).toBeTruthy();
+    expect(token.split('.')).toHaveLength(3);
+  });
+
+  it('should have 7 day expiration', () => {
+    const payload = { userId: 'user-123', email: 'test@example.com', role: 'user' as const };
+    const token = generateRefreshToken(payload);
+    const decoded = jwt.verify(token, 'test-secret-for-tokens') as { iat: number; exp: number };
+
+    const expiresIn = decoded.exp - decoded.iat;
+    expect(expiresIn).toBe(7 * 24 * 60 * 60); // 7 days in seconds
+  });
+});
+
+describe('generateParticipantToken', () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = 'test-secret-for-tokens';
+  });
+
+  it('should generate a valid JWT token', () => {
+    const payload = { participantId: 'participant-123', sessionId: 'session-456', displayName: 'John' };
+    const token = generateParticipantToken(payload);
+
+    expect(token).toBeTruthy();
+    expect(token.split('.')).toHaveLength(3);
+  });
+
+  it('should include participant payload', () => {
+    const payload = { participantId: 'participant-123', sessionId: 'session-456', displayName: 'John' };
+    const token = generateParticipantToken(payload);
+    const decoded = jwt.verify(token, 'test-secret-for-tokens') as typeof payload;
+
+    expect(decoded.participantId).toBe(payload.participantId);
+    expect(decoded.sessionId).toBe(payload.sessionId);
+    expect(decoded.displayName).toBe(payload.displayName);
+  });
+
+  it('should have 15 minute expiration', () => {
+    const payload = { participantId: 'participant-123', sessionId: 'session-456', displayName: 'John' };
+    const token = generateParticipantToken(payload);
+    const decoded = jwt.verify(token, 'test-secret-for-tokens') as { iat: number; exp: number };
+
+    const expiresIn = decoded.exp - decoded.iat;
+    expect(expiresIn).toBe(15 * 60); // 15 minutes in seconds
+  });
+});
+
+describe('verifyToken', () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = 'test-secret-for-tokens';
+  });
+
+  it('should verify a valid access token', () => {
+    const payload = { userId: 'user-123', email: 'test@example.com', role: 'user' as const };
+    const token = generateAccessToken(payload);
+    const decoded = verifyToken(token);
+
+    expect(decoded).toMatchObject(payload);
+  });
+
+  it('should verify a valid participant token', () => {
+    const payload = { participantId: 'participant-123', sessionId: 'session-456', displayName: 'John' };
+    const token = generateParticipantToken(payload);
+    const decoded = verifyToken(token);
+
+    expect(decoded).toMatchObject(payload);
+  });
+
+  it('should throw for invalid token', () => {
+    expect(() => verifyToken('invalid.token.here')).toThrow();
+  });
+
+  it('should throw for tampered token', () => {
+    const payload = { userId: 'user-123', email: 'test@example.com', role: 'user' as const };
+    const token = generateAccessToken(payload);
+    const tamperedToken = token.slice(0, -5) + 'xxxxx';
+
+    expect(() => verifyToken(tamperedToken)).toThrow();
+  });
+
+  it('should throw for token signed with different secret', () => {
+    const payload = { userId: 'user-123', email: 'test@example.com', role: 'user' as const };
+    const token = jwt.sign(payload, 'different-secret', { expiresIn: '15m' });
+
+    expect(() => verifyToken(token)).toThrow();
+  });
+
+  it('should throw for expired token', () => {
+    const payload = { userId: 'user-123', email: 'test@example.com', role: 'user' as const };
+    // Create an already-expired token
+    const token = jwt.sign(payload, 'test-secret-for-tokens', { expiresIn: '-1s' });
+
+    expect(() => verifyToken(token)).toThrow();
+  });
+});
+
+// Helper to create mock Express objects
+function createMockReq(overrides: Partial<AuthRequest> = {}): AuthRequest {
+  return {
+    cookies: {},
+    headers: {},
+    ...overrides,
+  } as AuthRequest;
+}
+
+function createMockRes(): Response {
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  };
+  return res as unknown as Response;
+}
+
+describe('authenticateUser middleware', () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = 'test-secret-for-tokens';
+  });
+
+  it('should authenticate with valid token in cookie', () => {
+    const payload = { userId: 'user-123', email: 'test@example.com', role: 'user' as const };
+    const token = generateAccessToken(payload);
+    const req = createMockReq({ cookies: { accessToken: token } });
+    const res = createMockRes();
+    const next = vi.fn() as NextFunction;
+
+    authenticateUser(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.userId).toBe('user-123');
+    expect(req.userRole).toBe('user');
+  });
+
+  it('should authenticate with valid token in Authorization header', () => {
+    const payload = { userId: 'user-123', email: 'test@example.com', role: 'user' as const };
+    const token = generateAccessToken(payload);
+    const req = createMockReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = createMockRes();
+    const next = vi.fn() as NextFunction;
+
+    authenticateUser(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.userId).toBe('user-123');
+  });
+
+  it('should return 401 when no token provided', () => {
+    const req = createMockReq();
+    const res = createMockRes();
+    const next = vi.fn() as NextFunction;
+
+    authenticateUser(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Authentication required' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should return 401 for invalid token', () => {
+    const req = createMockReq({ cookies: { accessToken: 'invalid-token' } });
+    const res = createMockRes();
+    const next = vi.fn() as NextFunction;
+
+    authenticateUser(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid or expired token' });
+  });
+
+  it('should return 401 for expired token', () => {
+    const payload = { userId: 'user-123', email: 'test@example.com', role: 'user' as const };
+    const token = jwt.sign(payload, 'test-secret-for-tokens', { expiresIn: '-1s' });
+    const req = createMockReq({ cookies: { accessToken: token } });
+    const res = createMockRes();
+    const next = vi.fn() as NextFunction;
+
+    authenticateUser(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid or expired token' });
+  });
+});
+
+describe('authenticateParticipant middleware', () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = 'test-secret-for-tokens';
+  });
+
+  it('should authenticate with valid participant token in cookie', () => {
+    const payload = { participantId: 'participant-123', sessionId: 'session-456', displayName: 'John' };
+    const token = generateParticipantToken(payload);
+    const req = createMockReq({ cookies: { participantToken: token } });
+    const res = createMockRes();
+    const next = vi.fn() as NextFunction;
+
+    authenticateParticipant(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.participantId).toBe('participant-123');
+  });
+
+  it('should authenticate with valid token in header', () => {
+    const payload = { participantId: 'participant-123', sessionId: 'session-456', displayName: 'John' };
+    const token = generateParticipantToken(payload);
+    const req = createMockReq({ headers: { 'x-participant-token': token } });
+    const res = createMockRes();
+    const next = vi.fn() as NextFunction;
+
+    authenticateParticipant(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.participantId).toBe('participant-123');
+  });
+
+  it('should return 401 when no token provided', () => {
+    const req = createMockReq();
+    const res = createMockRes();
+    const next = vi.fn() as NextFunction;
+
+    authenticateParticipant(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Participant authentication required' });
+  });
+
+  it('should return 401 for invalid token', () => {
+    const req = createMockReq({ cookies: { participantToken: 'invalid' } });
+    const res = createMockRes();
+    const next = vi.fn() as NextFunction;
+
+    authenticateParticipant(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid or expired participant token' });
+  });
+});
+
+describe('requireAdmin middleware', () => {
+  it('should call next for admin users', () => {
+    const req = createMockReq({ userRole: 'admin' });
+    const res = createMockRes();
+    const next = vi.fn() as NextFunction;
+
+    requireAdmin(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should return 403 for non-admin users', () => {
+    const req = createMockReq({ userRole: 'user' });
+    const res = createMockRes();
+    const next = vi.fn() as NextFunction;
+
+    requireAdmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Admin access required' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should return 403 when no role set', () => {
+    const req = createMockReq();
+    const res = createMockRes();
+    const next = vi.fn() as NextFunction;
+
+    requireAdmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Admin access required' });
+  });
+});
+
+describe('authenticateAny middleware', () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = 'test-secret-for-tokens';
+  });
+
+  it('should authenticate with valid user token', () => {
+    const payload = { userId: 'user-123', email: 'test@example.com', role: 'user' as const };
+    const token = generateAccessToken(payload);
+    const req = createMockReq({ cookies: { accessToken: token } });
+    const res = createMockRes();
+    const next = vi.fn() as NextFunction;
+
+    authenticateAny(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.userId).toBe('user-123');
+  });
+
+  it('should authenticate with valid participant token when user token fails', () => {
+    const payload = { participantId: 'participant-123', sessionId: 'session-456', displayName: 'John' };
+    const token = generateParticipantToken(payload);
+    const req = createMockReq({
+      cookies: { accessToken: 'invalid', participantToken: token },
+    });
+    const res = createMockRes();
+    const next = vi.fn() as NextFunction;
+
+    authenticateAny(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.participantId).toBe('participant-123');
+  });
+
+  it('should authenticate with participant token only', () => {
+    const payload = { participantId: 'participant-123', sessionId: 'session-456', displayName: 'John' };
+    const token = generateParticipantToken(payload);
+    const req = createMockReq({ cookies: { participantToken: token } });
+    const res = createMockRes();
+    const next = vi.fn() as NextFunction;
+
+    authenticateAny(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.participantId).toBe('participant-123');
+  });
+
+  it('should return 401 when no valid tokens', () => {
+    const req = createMockReq();
+    const res = createMockRes();
+    const next = vi.fn() as NextFunction;
+
+    authenticateAny(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Authentication required' });
+  });
+
+  it('should return 401 when both tokens are invalid', () => {
+    const req = createMockReq({
+      cookies: { accessToken: 'invalid', participantToken: 'also-invalid' },
+    });
+    const res = createMockRes();
+    const next = vi.fn() as NextFunction;
+
+    authenticateAny(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid or expired token' });
+  });
+});

--- a/server/src/middleware/rateLimit.test.ts
+++ b/server/src/middleware/rateLimit.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('rate limiters', () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    vi.resetModules();
+  });
+
+  describe('in development mode', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'development';
+      vi.resetModules();
+    });
+
+    it('should have high limit for authLimiter', async () => {
+      const { authLimiter } = await import('./rateLimit.js');
+      // In development, max should be 10000
+      expect(authLimiter).toBeDefined();
+    });
+
+    it('should have high limit for verificationLimiter', async () => {
+      const { verificationLimiter } = await import('./rateLimit.js');
+      expect(verificationLimiter).toBeDefined();
+    });
+
+    it('should have high limit for sessionJoinLimiter', async () => {
+      const { sessionJoinLimiter } = await import('./rateLimit.js');
+      expect(sessionJoinLimiter).toBeDefined();
+    });
+
+    it('should have high limit for generalLimiter', async () => {
+      const { generalLimiter } = await import('./rateLimit.js');
+      expect(generalLimiter).toBeDefined();
+    });
+
+    it('should have high limit for statsLimiter', async () => {
+      const { statsLimiter } = await import('./rateLimit.js');
+      expect(statsLimiter).toBeDefined();
+    });
+
+    it('should have high limit for exportLimiter', async () => {
+      const { exportLimiter } = await import('./rateLimit.js');
+      expect(exportLimiter).toBeDefined();
+    });
+
+    it('should have high limit for resultsLimiter', async () => {
+      const { resultsLimiter } = await import('./rateLimit.js');
+      expect(resultsLimiter).toBeDefined();
+    });
+  });
+
+  describe('in production mode', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production';
+      vi.resetModules();
+    });
+
+    it('should export all rate limiters', async () => {
+      const limiters = await import('./rateLimit.js');
+
+      expect(limiters.authLimiter).toBeDefined();
+      expect(limiters.verificationLimiter).toBeDefined();
+      expect(limiters.sessionJoinLimiter).toBeDefined();
+      expect(limiters.generalLimiter).toBeDefined();
+      expect(limiters.statsLimiter).toBeDefined();
+      expect(limiters.exportLimiter).toBeDefined();
+      expect(limiters.resultsLimiter).toBeDefined();
+    });
+  });
+});

--- a/server/src/utils/logger.test.ts
+++ b/server/src/utils/logger.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('logger', () => {
+  const originalEnv = process.env.NODE_ENV;
+  let consoleSpy: {
+    log: ReturnType<typeof vi.spyOn>;
+    warn: ReturnType<typeof vi.spyOn>;
+    error: ReturnType<typeof vi.spyOn>;
+  };
+
+  beforeEach(() => {
+    consoleSpy = {
+      log: vi.spyOn(console, 'log').mockImplementation(() => {}),
+      warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+      error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+    };
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  describe('in development mode', () => {
+    beforeEach(async () => {
+      process.env.NODE_ENV = 'development';
+      vi.resetModules();
+    });
+
+    it('should log debug messages', async () => {
+      const { logger } = await import('./logger.js');
+      logger.debug('test debug message');
+      expect(consoleSpy.log).toHaveBeenCalledWith('[DEBUG]', 'test debug message');
+    });
+
+    it('should log info messages', async () => {
+      const { logger } = await import('./logger.js');
+      logger.info('test info message');
+      expect(consoleSpy.log).toHaveBeenCalledWith('[INFO]', 'test info message');
+    });
+
+    it('should log warning messages', async () => {
+      const { logger } = await import('./logger.js');
+      logger.warn('test warning');
+      expect(consoleSpy.warn).toHaveBeenCalledWith('[WARN]', 'test warning');
+    });
+
+    it('should log error messages', async () => {
+      const { logger } = await import('./logger.js');
+      logger.error('test error');
+      expect(consoleSpy.error).toHaveBeenCalledWith('[ERROR]', 'test error');
+    });
+
+    it('should log dev messages', async () => {
+      const { logger } = await import('./logger.js');
+      logger.dev('test dev message');
+      expect(consoleSpy.log).toHaveBeenCalledWith('test dev message');
+    });
+
+    it('should handle multiple arguments', async () => {
+      const { logger } = await import('./logger.js');
+      logger.debug('message', { key: 'value' }, 123);
+      expect(consoleSpy.log).toHaveBeenCalledWith('[DEBUG]', 'message', { key: 'value' }, 123);
+    });
+  });
+
+  describe('in production mode', () => {
+    beforeEach(async () => {
+      process.env.NODE_ENV = 'production';
+      vi.resetModules();
+    });
+
+    it('should NOT log debug messages', async () => {
+      const { logger } = await import('./logger.js');
+      logger.debug('test debug message');
+      expect(consoleSpy.log).not.toHaveBeenCalled();
+    });
+
+    it('should NOT log info messages', async () => {
+      const { logger } = await import('./logger.js');
+      logger.info('test info message');
+      expect(consoleSpy.log).not.toHaveBeenCalled();
+    });
+
+    it('should still log warning messages', async () => {
+      const { logger } = await import('./logger.js');
+      logger.warn('test warning');
+      expect(consoleSpy.warn).toHaveBeenCalledWith('[WARN]', 'test warning');
+    });
+
+    it('should still log error messages', async () => {
+      const { logger } = await import('./logger.js');
+      logger.error('test error');
+      expect(consoleSpy.error).toHaveBeenCalledWith('[ERROR]', 'test error');
+    });
+
+    it('should NOT log dev messages', async () => {
+      const { logger } = await import('./logger.js');
+      logger.dev('test dev message');
+      expect(consoleSpy.log).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/src/utils/validation.test.ts
+++ b/server/src/utils/validation.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validatePassword,
+  validateEmail,
+  validateLength,
+  normalizeEmail,
+  validateImageMagicBytes,
+  INPUT_LIMITS,
+} from './validation.js';
+
+describe('validatePassword', () => {
+  it('should accept a valid password', () => {
+    const result = validatePassword('SecurePass123');
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('should reject password shorter than 12 characters', () => {
+    const result = validatePassword('Short1Aa');
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('Password must be at least 12 characters');
+  });
+
+  it('should reject password without lowercase letter', () => {
+    const result = validatePassword('ALLUPPERCASE123');
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('Password must contain a lowercase letter');
+  });
+
+  it('should reject password without uppercase letter', () => {
+    const result = validatePassword('alllowercase123');
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('Password must contain an uppercase letter');
+  });
+
+  it('should reject password without number', () => {
+    const result = validatePassword('NoNumbersHere');
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('Password must contain a number');
+  });
+
+  it('should return multiple errors for weak password', () => {
+    const result = validatePassword('weak');
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(1);
+  });
+
+  it('should accept password with special characters', () => {
+    const result = validatePassword('Secure@Pass#123!');
+    expect(result.valid).toBe(true);
+  });
+
+  it('should accept exactly 12 character password', () => {
+    const result = validatePassword('Abcdefgh1234');
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('validateEmail', () => {
+  it('should accept a valid email', () => {
+    const result = validateEmail('user@example.com');
+    expect(result.valid).toBe(true);
+  });
+
+  it('should accept email with subdomain', () => {
+    const result = validateEmail('user@mail.example.com');
+    expect(result.valid).toBe(true);
+  });
+
+  it('should accept email with plus addressing', () => {
+    const result = validateEmail('user+tag@example.com');
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject empty email', () => {
+    const result = validateEmail('');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Email is required');
+  });
+
+  it('should reject email without @', () => {
+    const result = validateEmail('userexample.com');
+    expect(result.valid).toBe(false);
+  });
+
+  it('should reject email without domain', () => {
+    const result = validateEmail('user@');
+    expect(result.valid).toBe(false);
+  });
+
+  it('should reject email without TLD', () => {
+    const result = validateEmail('user@localhost');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Email domain must include a valid TLD');
+  });
+
+  it('should reject email with consecutive dots', () => {
+    const result = validateEmail('user..name@example.com');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Email cannot contain consecutive dots');
+  });
+
+  it('should reject email starting with dot', () => {
+    const result = validateEmail('.user@example.com');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Email local part cannot start or end with a dot');
+  });
+
+  it('should reject email ending with dot in local part', () => {
+    const result = validateEmail('user.@example.com');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Email local part cannot start or end with a dot');
+  });
+
+  it('should reject email too short', () => {
+    const result = validateEmail('a@b');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Email is too short');
+  });
+
+  it('should reject email too long', () => {
+    const longLocal = 'a'.repeat(65);
+    const result = validateEmail(`${longLocal}@example.com`);
+    expect(result.valid).toBe(false);
+  });
+
+  it('should reject numeric-only TLD', () => {
+    const result = validateEmail('user@example.123');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid top-level domain');
+  });
+
+  it('should reject disposable email domains', () => {
+    const result = validateEmail('user@mailinator.com');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Disposable email addresses are not allowed');
+  });
+
+  it('should handle case insensitivity', () => {
+    const result = validateEmail('USER@EXAMPLE.COM');
+    expect(result.valid).toBe(true);
+  });
+
+  it('should trim whitespace', () => {
+    const result = validateEmail('  user@example.com  ');
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('validateLength', () => {
+  it('should accept string within limit', () => {
+    const result = validateLength('hello', 10, 'Field');
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('should accept string at exact limit', () => {
+    const result = validateLength('hello', 5, 'Field');
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject string over limit', () => {
+    const result = validateLength('hello world', 5, 'Field');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Field must be 5 characters or less');
+  });
+
+  it('should accept null value', () => {
+    const result = validateLength(null, 10, 'Field');
+    expect(result.valid).toBe(true);
+  });
+
+  it('should accept undefined value', () => {
+    const result = validateLength(undefined, 10, 'Field');
+    expect(result.valid).toBe(true);
+  });
+
+  it('should accept empty string', () => {
+    const result = validateLength('', 10, 'Field');
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('normalizeEmail', () => {
+  it('should lowercase email', () => {
+    expect(normalizeEmail('USER@EXAMPLE.COM')).toBe('user@example.com');
+  });
+
+  it('should trim whitespace', () => {
+    expect(normalizeEmail('  user@example.com  ')).toBe('user@example.com');
+  });
+
+  it('should handle mixed case', () => {
+    expect(normalizeEmail('UsEr@ExAmPlE.cOm')).toBe('user@example.com');
+  });
+});
+
+describe('validateImageMagicBytes', () => {
+  it('should detect JPEG image', () => {
+    const jpegBuffer = Buffer.from([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10]);
+    expect(validateImageMagicBytes(jpegBuffer)).toBe('image/jpeg');
+  });
+
+  it('should detect PNG image', () => {
+    const pngBuffer = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00]);
+    expect(validateImageMagicBytes(pngBuffer)).toBe('image/png');
+  });
+
+  it('should detect GIF image', () => {
+    const gifBuffer = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+    expect(validateImageMagicBytes(gifBuffer)).toBe('image/gif');
+  });
+
+  it('should detect WebP image', () => {
+    // RIFF....WEBP
+    const webpBuffer = Buffer.from([
+      0x52, 0x49, 0x46, 0x46, // RIFF
+      0x00, 0x00, 0x00, 0x00, // size placeholder
+      0x57, 0x45, 0x42, 0x50, // WEBP
+    ]);
+    expect(validateImageMagicBytes(webpBuffer)).toBe('image/webp');
+  });
+
+  it('should return null for invalid image', () => {
+    const textBuffer = Buffer.from('Hello, World!');
+    expect(validateImageMagicBytes(textBuffer)).toBeNull();
+  });
+
+  it('should return null for empty buffer', () => {
+    const emptyBuffer = Buffer.from([]);
+    expect(validateImageMagicBytes(emptyBuffer)).toBeNull();
+  });
+
+  it('should return null for RIFF without WEBP marker', () => {
+    const riffBuffer = Buffer.from([
+      0x52, 0x49, 0x46, 0x46, // RIFF
+      0x00, 0x00, 0x00, 0x00, // size
+      0x41, 0x56, 0x49, 0x20, // AVI (not WEBP)
+    ]);
+    expect(validateImageMagicBytes(riffBuffer)).toBeNull();
+  });
+});
+
+describe('INPUT_LIMITS', () => {
+  it('should have correct email limit (RFC 5321)', () => {
+    expect(INPUT_LIMITS.EMAIL).toBe(254);
+  });
+
+  it('should have password limit to prevent bcrypt DoS', () => {
+    expect(INPUT_LIMITS.PASSWORD).toBe(128);
+  });
+
+  it('should have reasonable limits for user fields', () => {
+    expect(INPUT_LIMITS.DISPLAY_NAME).toBe(100);
+    expect(INPUT_LIMITS.BIO).toBe(500);
+  });
+
+  it('should have limits for session fields', () => {
+    expect(INPUT_LIMITS.SESSION_NAME).toBe(100);
+    expect(INPUT_LIMITS.SESSION_THEME).toBe(50);
+    expect(INPUT_LIMITS.INVITE_CODE).toBe(20);
+  });
+
+  it('should have limits for whiskey fields', () => {
+    expect(INPUT_LIMITS.WHISKEY_NAME).toBe(200);
+    expect(INPUT_LIMITS.WHISKEY_DISTILLERY).toBe(200);
+    expect(INPUT_LIMITS.NOTES).toBe(2000);
+  });
+});

--- a/src/store/authStore.test.ts
+++ b/src/store/authStore.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useAuthStore } from './authStore';
+
+// Mock the authApi module
+vi.mock('@/services', () => ({
+  authApi: {
+    login: vi.fn(),
+    logout: vi.fn(),
+    me: vi.fn(),
+    refresh: vi.fn(),
+  },
+}));
+
+// Import mocked module
+import { authApi } from '@/services';
+
+describe('authStore', () => {
+  beforeEach(() => {
+    // Reset store state before each test
+    useAuthStore.setState({
+      user: null,
+      isAuthenticated: false,
+      isAdmin: false,
+      isLoading: false,
+      error: null,
+    });
+    vi.clearAllMocks();
+  });
+
+  describe('initial state', () => {
+    it('should have correct initial state', () => {
+      const state = useAuthStore.getState();
+
+      expect(state.user).toBeNull();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.isAdmin).toBe(false);
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBeNull();
+    });
+  });
+
+  describe('login', () => {
+    it('should set loading state while logging in', async () => {
+      const mockUser = { id: '1', email: 'test@example.com', displayName: 'Test User', role: 'user' };
+      vi.mocked(authApi.login).mockImplementation(async () => {
+        expect(useAuthStore.getState().isLoading).toBe(true);
+        return { user: mockUser };
+      });
+
+      await useAuthStore.getState().login('test@example.com', 'password123');
+    });
+
+    it('should set user and authentication state on successful login', async () => {
+      const mockUser = { id: '1', email: 'test@example.com', displayName: 'Test User', role: 'user' };
+      vi.mocked(authApi.login).mockResolvedValue({ user: mockUser });
+
+      await useAuthStore.getState().login('test@example.com', 'password123');
+
+      const state = useAuthStore.getState();
+      expect(state.user).toMatchObject(mockUser);
+      expect(state.isAuthenticated).toBe(true);
+      expect(state.isAdmin).toBe(false);
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBeNull();
+    });
+
+    it('should set isAdmin for admin users', async () => {
+      const mockUser = { id: '1', email: 'admin@example.com', displayName: 'Admin', role: 'admin' };
+      vi.mocked(authApi.login).mockResolvedValue({ user: mockUser });
+
+      await useAuthStore.getState().login('admin@example.com', 'password123');
+
+      const state = useAuthStore.getState();
+      expect(state.isAdmin).toBe(true);
+    });
+
+    it('should set error state on login failure', async () => {
+      const errorMessage = 'Invalid credentials';
+      vi.mocked(authApi.login).mockRejectedValue(new Error(errorMessage));
+
+      await expect(useAuthStore.getState().login('test@example.com', 'wrong')).rejects.toThrow(errorMessage);
+
+      const state = useAuthStore.getState();
+      expect(state.user).toBeNull();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBe(errorMessage);
+    });
+
+    it('should call authApi.login with correct credentials', async () => {
+      const mockUser = { id: '1', email: 'test@example.com', displayName: 'Test', role: 'user' };
+      vi.mocked(authApi.login).mockResolvedValue({ user: mockUser });
+
+      await useAuthStore.getState().login('test@example.com', 'password123');
+
+      expect(authApi.login).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'password123',
+      });
+    });
+  });
+
+  describe('logout', () => {
+    it('should clear user state on logout', async () => {
+      // Set up authenticated state
+      useAuthStore.setState({
+        user: { id: '1', email: 'test@example.com', displayName: 'Test', role: 'user' },
+        isAuthenticated: true,
+        isAdmin: false,
+      });
+
+      vi.mocked(authApi.logout).mockResolvedValue(undefined);
+
+      await useAuthStore.getState().logout();
+
+      const state = useAuthStore.getState();
+      expect(state.user).toBeNull();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.isAdmin).toBe(false);
+    });
+
+    it('should clear state even if logout API fails', async () => {
+      useAuthStore.setState({
+        user: { id: '1', email: 'test@example.com', displayName: 'Test', role: 'user' },
+        isAuthenticated: true,
+      });
+
+      vi.mocked(authApi.logout).mockRejectedValue(new Error('Network error'));
+
+      // The error propagates but the finally block still clears state
+      try {
+        await useAuthStore.getState().logout();
+      } catch {
+        // Expected to throw
+      }
+
+      const state = useAuthStore.getState();
+      expect(state.user).toBeNull();
+      expect(state.isAuthenticated).toBe(false);
+    });
+  });
+
+  describe('checkAuth', () => {
+    it('should set loading state while checking auth', async () => {
+      const mockUser = { id: '1', email: 'test@example.com', displayName: 'Test', role: 'user' };
+      vi.mocked(authApi.me).mockImplementation(async () => {
+        expect(useAuthStore.getState().isLoading).toBe(true);
+        return mockUser;
+      });
+
+      await useAuthStore.getState().checkAuth();
+    });
+
+    it('should set authenticated state on successful check', async () => {
+      const mockUser = {
+        id: '1',
+        email: 'test@example.com',
+        displayName: 'Test User',
+        role: 'user',
+        avatarUrl: null,
+        bio: null,
+        favoriteCategory: null,
+        experienceLevel: null,
+        isProfilePublic: true,
+      };
+      vi.mocked(authApi.me).mockResolvedValue(mockUser);
+
+      await useAuthStore.getState().checkAuth();
+
+      const state = useAuthStore.getState();
+      expect(state.isAuthenticated).toBe(true);
+      expect(state.user?.email).toBe('test@example.com');
+      expect(state.isLoading).toBe(false);
+    });
+
+    it('should try refresh when initial auth check fails', async () => {
+      const mockUser = {
+        id: '1',
+        email: 'test@example.com',
+        displayName: 'Test',
+        role: 'user',
+      };
+
+      vi.mocked(authApi.me)
+        .mockRejectedValueOnce(new Error('Unauthorized'))
+        .mockResolvedValueOnce(mockUser);
+      vi.mocked(authApi.refresh).mockResolvedValue(undefined);
+
+      await useAuthStore.getState().checkAuth();
+
+      expect(authApi.refresh).toHaveBeenCalled();
+      expect(useAuthStore.getState().isAuthenticated).toBe(true);
+    });
+
+    it('should clear state if refresh also fails', async () => {
+      vi.mocked(authApi.me).mockRejectedValue(new Error('Unauthorized'));
+      vi.mocked(authApi.refresh).mockRejectedValue(new Error('Invalid refresh token'));
+
+      await useAuthStore.getState().checkAuth();
+
+      const state = useAuthStore.getState();
+      expect(state.user).toBeNull();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.isLoading).toBe(false);
+    });
+  });
+
+  describe('setLoading', () => {
+    it('should set loading state', () => {
+      useAuthStore.getState().setLoading(true);
+      expect(useAuthStore.getState().isLoading).toBe(true);
+
+      useAuthStore.getState().setLoading(false);
+      expect(useAuthStore.getState().isLoading).toBe(false);
+    });
+  });
+
+  describe('setUser', () => {
+    it('should set user and mark as authenticated', () => {
+      const user = { id: '1', email: 'test@example.com', displayName: 'Test', role: 'user' as const };
+
+      useAuthStore.getState().setUser(user);
+
+      const state = useAuthStore.getState();
+      expect(state.user).toMatchObject(user);
+      expect(state.isAuthenticated).toBe(true);
+      expect(state.isAdmin).toBe(false);
+    });
+
+    it('should set isAdmin for admin user', () => {
+      const user = { id: '1', email: 'admin@example.com', displayName: 'Admin', role: 'admin' as const };
+
+      useAuthStore.getState().setUser(user);
+
+      expect(useAuthStore.getState().isAdmin).toBe(true);
+    });
+  });
+
+  describe('clearError', () => {
+    it('should clear error state', () => {
+      useAuthStore.setState({ error: 'Some error' });
+
+      useAuthStore.getState().clearError();
+
+      expect(useAuthStore.getState().error).toBeNull();
+    });
+  });
+
+  describe('register', () => {
+    it('should throw with guidance to use authApi directly', async () => {
+      await expect(
+        useAuthStore.getState().register('test@example.com', 'password', 'Test')
+      ).rejects.toThrow('Use authApi.register directly');
+    });
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
@@ -8,6 +9,17 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': '/src',
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.{test,spec}.{js,ts,tsx}', 'server/**/*.{test,spec}.{js,ts}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', 'dist/', 'server/dist/'],
     },
   },
 })


### PR DESCRIPTION
## Summary
- Set up Vitest testing framework with jsdom environment
- Add 115 unit tests achieving 97.36% statement coverage
- Configure v8 coverage reporting

## Tests Added
| File | Tests | Coverage |
|------|-------|----------|
| validation.test.ts | 45 | 95% |
| auth.test.ts | 34 | 98% |
| authStore.test.ts | 17 | 100% |
| logger.test.ts | 11 | 100% |
| rateLimit.test.ts | 8 | 100% |

## Test Commands
- `npm test` - Run tests in watch mode
- `npm run test:run` - Run tests once
- `npm run test:coverage` - Run with coverage report

## Test plan
- [x] All 115 tests pass
- [x] Coverage meets 97%+ threshold
- [x] Tests run in CI-compatible mode (vitest run)