### PR TITLE
Add integration tests for API endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
+        "@types/supertest": "^6.0.3",
         "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^5.1.1",
         "@vitest/coverage-v8": "^4.0.18",
@@ -57,6 +58,7 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
         "jsdom": "^27.4.0",
+        "supertest": "^7.2.2",
         "tailwindcss": "^4.1.18",
         "tsx": "^4.21.0",
         "typescript": "~5.9.3",
@@ -1330,6 +1332,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.53",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
@@ -2185,6 +2210,13 @@
         "@types/express": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -2257,6 +2289,13 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -2337,6 +2376,30 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/@types/uuid": {
@@ -2901,6 +2964,13 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2927,6 +2997,13 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3282,6 +3359,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3413,6 +3513,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -3598,6 +3705,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3624,6 +3741,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -4069,6 +4197,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -4475,6 +4619,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-sha256": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
@@ -4576,6 +4727,64 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -4761,6 +4970,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -5840,6 +6065,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -7276,6 +7524,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -56,6 +57,7 @@
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
+    "@types/supertest": "^6.0.3",
     "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^5.1.1",
     "@vitest/coverage-v8": "^4.0.18",
@@ -66,6 +68,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "jsdom": "^27.4.0",
+    "supertest": "^7.2.2",
     "tailwindcss": "^4.1.18",
     "tsx": "^4.21.0",
     "typescript": "~5.9.3",

--- a/server/src/__tests__/integration/auth.integration.test.ts
+++ b/server/src/__tests__/integration/auth.integration.test.ts
@@ -1,0 +1,634 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express, { Express } from 'express';
+import cookieParser from 'cookie-parser';
+import Database from 'better-sqlite3';
+import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import * as schema from '../../db/schema.js';
+
+// Set JWT_SECRET for tests
+process.env.JWT_SECRET = 'test-jwt-secret-for-integration-tests';
+
+// Create test database instance that will be shared
+const sqlite = new Database(':memory:');
+sqlite.pragma('foreign_keys = ON');
+const testDb = drizzle(sqlite, { schema });
+
+// Initialize database schema
+sqlite.exec(`
+  CREATE TABLE IF NOT EXISTS users (
+    id TEXT PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    avatar_url TEXT,
+    bio TEXT,
+    favorite_category TEXT,
+    experience_level TEXT,
+    role TEXT NOT NULL DEFAULT 'user',
+    is_profile_public INTEGER NOT NULL DEFAULT 1,
+    email_verified INTEGER NOT NULL DEFAULT 0,
+    verification_code TEXT,
+    verification_code_expires_at INTEGER,
+    reset_password_code TEXT,
+    reset_password_code_expires_at INTEGER,
+    verification_attempts INTEGER NOT NULL DEFAULT 0,
+    verification_locked_until INTEGER,
+    reset_password_attempts INTEGER NOT NULL DEFAULT 0,
+    reset_password_locked_until INTEGER,
+    deleted_at INTEGER,
+    created_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token TEXT NOT NULL UNIQUE,
+    expires_at INTEGER NOT NULL,
+    created_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS audit_logs (
+    id TEXT PRIMARY KEY,
+    action TEXT NOT NULL,
+    user_id TEXT,
+    target_user_id TEXT,
+    ip_address TEXT,
+    user_agent TEXT,
+    metadata TEXT,
+    created_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS sessions (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    theme TEXT NOT NULL,
+    custom_theme TEXT,
+    proof_min INTEGER,
+    proof_max INTEGER,
+    scheduled_at INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'draft',
+    moderator_id TEXT NOT NULL REFERENCES users(id),
+    current_whiskey_index INTEGER NOT NULL DEFAULT 0,
+    current_phase TEXT NOT NULL DEFAULT 'pour',
+    invite_code TEXT NOT NULL UNIQUE,
+    max_participants INTEGER,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS participants (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    user_id TEXT REFERENCES users(id),
+    display_name TEXT NOT NULL,
+    joined_at INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'waiting',
+    is_ready INTEGER NOT NULL DEFAULT 0,
+    current_whiskey_index INTEGER NOT NULL DEFAULT 0
+  );
+
+  CREATE TABLE IF NOT EXISTS follows (
+    id TEXT PRIMARY KEY,
+    follower_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    following_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at INTEGER NOT NULL,
+    UNIQUE(follower_id, following_id)
+  );
+
+  CREATE TABLE IF NOT EXISTS whiskeys (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    display_number INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    distillery TEXT NOT NULL,
+    age INTEGER,
+    proof REAL NOT NULL,
+    price REAL,
+    mashbill TEXT,
+    region TEXT,
+    pour_size TEXT NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS scores (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    whiskey_id TEXT NOT NULL REFERENCES whiskeys(id) ON DELETE CASCADE,
+    participant_id TEXT NOT NULL REFERENCES participants(id) ON DELETE CASCADE,
+    nose INTEGER NOT NULL,
+    palate INTEGER NOT NULL,
+    finish INTEGER NOT NULL,
+    overall INTEGER NOT NULL,
+    total_score REAL NOT NULL,
+    nose_notes TEXT,
+    palate_notes TEXT,
+    finish_notes TEXT,
+    general_notes TEXT,
+    identity_guess TEXT,
+    is_public INTEGER NOT NULL DEFAULT 0,
+    locked_at INTEGER NOT NULL
+  );
+`);
+
+// Mock socket.io
+vi.mock('../../socket/index.js', () => ({
+  getIO: () => ({
+    to: () => ({
+      emit: vi.fn(),
+    }),
+  }),
+}));
+
+// Mock email service
+vi.mock('../../services/email.js', () => ({
+  generateVerificationCode: () => 'ABC123',
+  getCodeExpiration: () => new Date(Date.now() + 15 * 60 * 1000),
+  getPasswordResetCodeExpiration: () => new Date(Date.now() + 15 * 60 * 1000),
+  sendVerificationEmail: vi.fn().mockResolvedValue({ success: true, devCode: 'ABC123' }),
+  sendPasswordResetEmail: vi.fn().mockResolvedValue({ success: true, devCode: 'ABC123' }),
+}));
+
+// Mock the db module to use our test database
+vi.mock('../../db/index.js', () => ({
+  db: testDb,
+  schema,
+}));
+
+let app: Express;
+
+async function createTestApp() {
+  const authRoutes = (await import('../../routes/auth.js')).default;
+
+  const testApp = express();
+  testApp.use(express.json());
+  testApp.use(cookieParser());
+  testApp.use('/api/auth', authRoutes);
+
+  testApp.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    console.error('Test server error:', err.message);
+    res.status(500).json({ error: 'Internal server error' });
+  });
+
+  return testApp;
+}
+
+describe('Auth Integration Tests', () => {
+  beforeAll(async () => {
+    app = await createTestApp();
+  });
+
+  afterAll(() => {
+    sqlite.close();
+  });
+
+  beforeEach(() => {
+    sqlite.exec(`
+      DELETE FROM audit_logs;
+      DELETE FROM scores;
+      DELETE FROM participants;
+      DELETE FROM whiskeys;
+      DELETE FROM sessions;
+      DELETE FROM follows;
+      DELETE FROM refresh_tokens;
+      DELETE FROM users;
+    `);
+  });
+
+  describe('POST /api/auth/register', () => {
+    it('should register a new user and return verification required', async () => {
+      const response = await request(app)
+        .post('/api/auth/register')
+        .send({
+          email: 'test@example.com',
+          password: 'ValidPassword123!',
+          displayName: 'Test User',
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body.requiresVerification).toBe(true);
+      expect(response.body.email).toBe('test@example.com');
+    });
+
+    it('should reject registration with weak password', async () => {
+      const response = await request(app)
+        .post('/api/auth/register')
+        .send({
+          email: 'test@example.com',
+          password: 'weak',
+          displayName: 'Test User',
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('12 characters');
+    });
+
+    it('should reject registration with invalid email', async () => {
+      const response = await request(app)
+        .post('/api/auth/register')
+        .send({
+          email: 'invalid-email',
+          password: 'ValidPassword123!',
+          displayName: 'Test User',
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('email');
+    });
+
+    it('should reject registration with missing fields', async () => {
+      const response = await request(app)
+        .post('/api/auth/register')
+        .send({
+          email: 'test@example.com',
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('required');
+    });
+
+    it('should reject duplicate email registration for verified user', async () => {
+      await request(app)
+        .post('/api/auth/register')
+        .send({
+          email: 'test@example.com',
+          password: 'ValidPassword123!',
+          displayName: 'Test User',
+        });
+
+      sqlite.exec(`UPDATE users SET email_verified = 1 WHERE email = 'test@example.com'`);
+
+      const response = await request(app)
+        .post('/api/auth/register')
+        .send({
+          email: 'test@example.com',
+          password: 'AnotherPassword123!',
+          displayName: 'Another User',
+        });
+
+      expect(response.status).toBe(409);
+      expect(response.body.error).toContain('already registered');
+    });
+  });
+
+  describe('POST /api/auth/verify-email', () => {
+    beforeEach(async () => {
+      await request(app)
+        .post('/api/auth/register')
+        .send({
+          email: 'verify@example.com',
+          password: 'ValidPassword123!',
+          displayName: 'Verify User',
+        });
+    });
+
+    it('should verify email with correct code', async () => {
+      const response = await request(app)
+        .post('/api/auth/verify-email')
+        .send({
+          email: 'verify@example.com',
+          code: 'ABC123',
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.user).toBeDefined();
+      expect(response.body.user.email).toBe('verify@example.com');
+      expect(response.body.accessToken).toBeDefined();
+    });
+
+    it('should reject verification with wrong code', async () => {
+      const response = await request(app)
+        .post('/api/auth/verify-email')
+        .send({
+          email: 'verify@example.com',
+          code: 'WRONG1',
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('Invalid verification code');
+    });
+
+    it('should reject already verified email', async () => {
+      await request(app)
+        .post('/api/auth/verify-email')
+        .send({
+          email: 'verify@example.com',
+          code: 'ABC123',
+        });
+
+      const response = await request(app)
+        .post('/api/auth/verify-email')
+        .send({
+          email: 'verify@example.com',
+          code: 'ABC123',
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('already verified');
+    });
+  });
+
+  describe('POST /api/auth/login', () => {
+    it('should login with valid credentials', async () => {
+      // Register and verify the user
+      await request(app)
+        .post('/api/auth/register')
+        .send({
+          email: 'login@example.com',
+          password: 'ValidPassword123!',
+          displayName: 'Login User',
+        });
+
+      // Manually verify in database to avoid creating a refresh token
+      sqlite.exec(`UPDATE users SET email_verified = 1, verification_code = NULL WHERE email = 'login@example.com'`);
+
+      const response = await request(app)
+        .post('/api/auth/login')
+        .send({
+          email: 'login@example.com',
+          password: 'ValidPassword123!',
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.user).toBeDefined();
+      expect(response.body.user.email).toBe('login@example.com');
+      expect(response.body.accessToken).toBeDefined();
+    });
+
+    it('should reject login with wrong password', async () => {
+      await request(app)
+        .post('/api/auth/register')
+        .send({
+          email: 'wrongpw@example.com',
+          password: 'ValidPassword123!',
+          displayName: 'Wrong Password User',
+        });
+
+      sqlite.exec(`UPDATE users SET email_verified = 1 WHERE email = 'wrongpw@example.com'`);
+
+      const response = await request(app)
+        .post('/api/auth/login')
+        .send({
+          email: 'wrongpw@example.com',
+          password: 'WrongPassword123!',
+        });
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toContain('Invalid credentials');
+    });
+
+    it('should reject login for non-existent user', async () => {
+      const response = await request(app)
+        .post('/api/auth/login')
+        .send({
+          email: 'nonexistent@example.com',
+          password: 'ValidPassword123!',
+        });
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toContain('Invalid credentials');
+    });
+
+    it('should reject login for unverified user', async () => {
+      await request(app)
+        .post('/api/auth/register')
+        .send({
+          email: 'unverified@example.com',
+          password: 'ValidPassword123!',
+          displayName: 'Unverified User',
+        });
+
+      const response = await request(app)
+        .post('/api/auth/login')
+        .send({
+          email: 'unverified@example.com',
+          password: 'ValidPassword123!',
+        });
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toContain('not verified');
+      expect(response.body.requiresVerification).toBe(true);
+    });
+  });
+
+  describe('GET /api/auth/me', () => {
+    it('should return current user with valid token', async () => {
+      await request(app)
+        .post('/api/auth/register')
+        .send({
+          email: 'me@example.com',
+          password: 'ValidPassword123!',
+          displayName: 'Me User',
+        });
+
+      const verifyResponse = await request(app)
+        .post('/api/auth/verify-email')
+        .send({
+          email: 'me@example.com',
+          code: 'ABC123',
+        });
+
+      const token = verifyResponse.body.accessToken;
+
+      const response = await request(app)
+        .get('/api/auth/me')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.email).toBe('me@example.com');
+      expect(response.body.displayName).toBe('Me User');
+    });
+
+    it('should reject request without token', async () => {
+      const response = await request(app).get('/api/auth/me');
+
+      expect(response.status).toBe(401);
+    });
+
+    it('should reject request with invalid token', async () => {
+      const response = await request(app)
+        .get('/api/auth/me')
+        .set('Authorization', 'Bearer invalid-token');
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('POST /api/auth/logout', () => {
+    it('should logout successfully', async () => {
+      await request(app)
+        .post('/api/auth/register')
+        .send({
+          email: 'logout@example.com',
+          password: 'ValidPassword123!',
+          displayName: 'Logout User',
+        });
+
+      const verifyResponse = await request(app)
+        .post('/api/auth/verify-email')
+        .send({
+          email: 'logout@example.com',
+          code: 'ABC123',
+        });
+
+      const cookies = verifyResponse.headers['set-cookie'];
+
+      const response = await request(app)
+        .post('/api/auth/logout')
+        .set('Cookie', cookies || []);
+
+      expect(response.status).toBe(200);
+      expect(response.body.message).toContain('Logged out');
+    });
+  });
+
+  describe('PATCH /api/auth/me/display-name', () => {
+    it('should update display name', async () => {
+      await request(app)
+        .post('/api/auth/register')
+        .send({
+          email: 'update@example.com',
+          password: 'ValidPassword123!',
+          displayName: 'Original Name',
+        });
+
+      const verifyResponse = await request(app)
+        .post('/api/auth/verify-email')
+        .send({
+          email: 'update@example.com',
+          code: 'ABC123',
+        });
+
+      const token = verifyResponse.body.accessToken;
+
+      const response = await request(app)
+        .patch('/api/auth/me/display-name')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ displayName: 'New Name' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.displayName).toBe('New Name');
+    });
+
+    it('should reject display name that is too short', async () => {
+      await request(app)
+        .post('/api/auth/register')
+        .send({
+          email: 'short@example.com',
+          password: 'ValidPassword123!',
+          displayName: 'Short Test',
+        });
+
+      const verifyResponse = await request(app)
+        .post('/api/auth/verify-email')
+        .send({
+          email: 'short@example.com',
+          code: 'ABC123',
+        });
+
+      const token = verifyResponse.body.accessToken;
+
+      const response = await request(app)
+        .patch('/api/auth/me/display-name')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ displayName: 'A' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('between 2 and 30');
+    });
+  });
+
+  describe('POST /api/auth/forgot-password', () => {
+    beforeEach(async () => {
+      await request(app)
+        .post('/api/auth/register')
+        .send({
+          email: 'forgot@example.com',
+          password: 'ValidPassword123!',
+          displayName: 'Forgot User',
+        });
+
+      await request(app)
+        .post('/api/auth/verify-email')
+        .send({
+          email: 'forgot@example.com',
+          code: 'ABC123',
+        });
+    });
+
+    it('should send password reset email for existing user', async () => {
+      const response = await request(app)
+        .post('/api/auth/forgot-password')
+        .send({ email: 'forgot@example.com' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.message).toContain('reset code');
+    });
+
+    it('should return success for non-existent user (prevent enumeration)', async () => {
+      const response = await request(app)
+        .post('/api/auth/forgot-password')
+        .send({ email: 'nonexistent@example.com' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.message).toContain('If that email exists');
+    });
+  });
+
+  describe('POST /api/auth/reset-password', () => {
+    beforeEach(async () => {
+      await request(app)
+        .post('/api/auth/register')
+        .send({
+          email: 'reset@example.com',
+          password: 'ValidPassword123!',
+          displayName: 'Reset User',
+        });
+
+      await request(app)
+        .post('/api/auth/verify-email')
+        .send({
+          email: 'reset@example.com',
+          code: 'ABC123',
+        });
+
+      await request(app)
+        .post('/api/auth/forgot-password')
+        .send({ email: 'reset@example.com' });
+    });
+
+    it('should reset password with valid code', async () => {
+      const response = await request(app)
+        .post('/api/auth/reset-password')
+        .send({
+          email: 'reset@example.com',
+          code: 'ABC123',
+          newPassword: 'NewValidPassword123!',
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.message).toContain('reset successfully');
+
+      const loginResponse = await request(app)
+        .post('/api/auth/login')
+        .send({
+          email: 'reset@example.com',
+          password: 'NewValidPassword123!',
+        });
+
+      expect(loginResponse.status).toBe(200);
+    });
+
+    it('should reject weak new password', async () => {
+      const response = await request(app)
+        .post('/api/auth/reset-password')
+        .send({
+          email: 'reset@example.com',
+          code: 'ABC123',
+          newPassword: 'weak',
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('12 characters');
+    });
+  });
+});

--- a/server/src/__tests__/integration/scores.integration.test.ts
+++ b/server/src/__tests__/integration/scores.integration.test.ts
@@ -1,0 +1,632 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express, { Express } from 'express';
+import cookieParser from 'cookie-parser';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import * as schema from '../../db/schema.js';
+
+// Set JWT_SECRET for tests
+process.env.JWT_SECRET = 'test-jwt-secret-for-integration-tests';
+
+// Create test database instance
+const sqlite = new Database(':memory:');
+sqlite.pragma('foreign_keys = ON');
+const testDb = drizzle(sqlite, { schema });
+
+// Initialize database schema
+sqlite.exec(`
+  CREATE TABLE IF NOT EXISTS users (
+    id TEXT PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    avatar_url TEXT,
+    bio TEXT,
+    favorite_category TEXT,
+    experience_level TEXT,
+    role TEXT NOT NULL DEFAULT 'user',
+    is_profile_public INTEGER NOT NULL DEFAULT 1,
+    email_verified INTEGER NOT NULL DEFAULT 0,
+    verification_code TEXT,
+    verification_code_expires_at INTEGER,
+    reset_password_code TEXT,
+    reset_password_code_expires_at INTEGER,
+    verification_attempts INTEGER NOT NULL DEFAULT 0,
+    verification_locked_until INTEGER,
+    reset_password_attempts INTEGER NOT NULL DEFAULT 0,
+    reset_password_locked_until INTEGER,
+    deleted_at INTEGER,
+    created_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS sessions (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    theme TEXT NOT NULL,
+    custom_theme TEXT,
+    proof_min INTEGER,
+    proof_max INTEGER,
+    scheduled_at INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'draft',
+    moderator_id TEXT NOT NULL REFERENCES users(id),
+    current_whiskey_index INTEGER NOT NULL DEFAULT 0,
+    current_phase TEXT NOT NULL DEFAULT 'pour',
+    invite_code TEXT NOT NULL UNIQUE,
+    max_participants INTEGER,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS whiskeys (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    display_number INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    distillery TEXT NOT NULL,
+    age INTEGER,
+    proof REAL NOT NULL,
+    price REAL,
+    mashbill TEXT,
+    region TEXT,
+    pour_size TEXT NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS participants (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    user_id TEXT REFERENCES users(id),
+    display_name TEXT NOT NULL,
+    joined_at INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'waiting',
+    is_ready INTEGER NOT NULL DEFAULT 0,
+    current_whiskey_index INTEGER NOT NULL DEFAULT 0
+  );
+
+  CREATE TABLE IF NOT EXISTS scores (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    whiskey_id TEXT NOT NULL REFERENCES whiskeys(id) ON DELETE CASCADE,
+    participant_id TEXT NOT NULL REFERENCES participants(id) ON DELETE CASCADE,
+    nose INTEGER NOT NULL,
+    palate INTEGER NOT NULL,
+    finish INTEGER NOT NULL,
+    overall INTEGER NOT NULL,
+    total_score REAL NOT NULL,
+    nose_notes TEXT,
+    palate_notes TEXT,
+    finish_notes TEXT,
+    general_notes TEXT,
+    identity_guess TEXT,
+    is_public INTEGER NOT NULL DEFAULT 0,
+    locked_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token TEXT NOT NULL UNIQUE,
+    expires_at INTEGER NOT NULL,
+    created_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS audit_logs (
+    id TEXT PRIMARY KEY,
+    action TEXT NOT NULL,
+    user_id TEXT,
+    target_user_id TEXT,
+    ip_address TEXT,
+    user_agent TEXT,
+    metadata TEXT,
+    created_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS follows (
+    id TEXT PRIMARY KEY,
+    follower_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    following_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at INTEGER NOT NULL,
+    UNIQUE(follower_id, following_id)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_sessions_invite_code ON sessions(invite_code);
+  CREATE INDEX IF NOT EXISTS idx_participants_session ON participants(session_id);
+`);
+
+// Mock socket.io
+vi.mock('../../socket/index.js', () => ({
+  getIO: () => ({
+    to: () => ({
+      emit: vi.fn(),
+    }),
+  }),
+}));
+
+// Mock email service
+vi.mock('../../services/email.js', () => ({
+  generateVerificationCode: () => 'ABC123',
+  getCodeExpiration: () => new Date(Date.now() + 15 * 60 * 1000),
+  getPasswordResetCodeExpiration: () => new Date(Date.now() + 15 * 60 * 1000),
+  sendVerificationEmail: vi.fn().mockResolvedValue({ success: true, devCode: 'ABC123' }),
+  sendPasswordResetEmail: vi.fn().mockResolvedValue({ success: true, devCode: 'ABC123' }),
+}));
+
+// Mock the db module to use our test database
+vi.mock('../../db/index.js', () => ({
+  db: testDb,
+  schema,
+}));
+
+let app: Express;
+
+async function createTestApp() {
+  const authRoutes = (await import('../../routes/auth.js')).default;
+  const sessionsRoutes = (await import('../../routes/sessions.js')).default;
+  const scoresRoutes = (await import('../../routes/scores.js')).default;
+
+  const testApp = express();
+  testApp.use(express.json());
+  testApp.use(cookieParser());
+  testApp.use('/api/auth', authRoutes);
+  testApp.use('/api/sessions', sessionsRoutes);
+  testApp.use('/api/scores', scoresRoutes);
+
+  testApp.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    console.error('Test server error:', err.message);
+    res.status(500).json({ error: 'Internal server error' });
+  });
+
+  return testApp;
+}
+
+async function createVerifiedUser(email: string, displayName: string) {
+  await request(app)
+    .post('/api/auth/register')
+    .send({
+      email,
+      password: 'ValidPassword123!',
+      displayName,
+    });
+
+  const verifyResponse = await request(app)
+    .post('/api/auth/verify-email')
+    .send({
+      email,
+      code: 'ABC123',
+    });
+
+  return {
+    token: verifyResponse.body.accessToken,
+    user: verifyResponse.body.user,
+  };
+}
+
+async function createTestSession(moderatorToken: string) {
+  const createResponse = await request(app)
+    .post('/api/sessions')
+    .set('Authorization', `Bearer ${moderatorToken}`)
+    .send({
+      name: 'Test Tasting Session',
+      hostName: 'Moderator',
+      theme: 'bourbon',
+      whiskeys: [
+        { name: 'Buffalo Trace', distillery: 'Buffalo Trace', proof: 90, pourSize: '0.5oz' },
+        { name: 'Eagle Rare', distillery: 'Buffalo Trace', proof: 90, pourSize: '0.5oz' },
+      ],
+    });
+
+  const sessionId = createResponse.body.id;
+  const participantToken = createResponse.body.participantToken;
+  const inviteCode = createResponse.body.inviteCode;
+
+  const sessionResponse = await request(app)
+    .get(`/api/sessions/${sessionId}`)
+    .set('Authorization', `Bearer ${moderatorToken}`);
+
+  return {
+    sessionId,
+    participantToken,
+    inviteCode,
+    whiskeys: sessionResponse.body.whiskeys,
+  };
+}
+
+describe('Scores Integration Tests', () => {
+  beforeAll(async () => {
+    app = await createTestApp();
+  });
+
+  afterAll(() => {
+    sqlite.close();
+  });
+
+  beforeEach(() => {
+    sqlite.exec(`
+      DELETE FROM audit_logs;
+      DELETE FROM scores;
+      DELETE FROM participants;
+      DELETE FROM whiskeys;
+      DELETE FROM sessions;
+      DELETE FROM follows;
+      DELETE FROM refresh_tokens;
+      DELETE FROM users;
+    `);
+  });
+
+  describe('POST /api/scores', () => {
+    it('should submit a score for a whiskey', async () => {
+      const { token: moderatorToken } = await createVerifiedUser('moderator@example.com', 'Moderator');
+      const { sessionId, participantToken, whiskeys } = await createTestSession(moderatorToken);
+
+      await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      const response = await request(app)
+        .post('/api/scores')
+        .set('x-participant-token', participantToken)
+        .send({
+          sessionId,
+          whiskeyId: whiskeys[0].id,
+          nose: 8,
+          palate: 7,
+          finish: 8,
+          overall: 8,
+          noseNotes: 'Vanilla, caramel',
+          palateNotes: 'Smooth, oaky',
+          finishNotes: 'Long and warm',
+          generalNotes: 'Great bourbon',
+          identityGuess: 'Buffalo Trace',
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body.id).toBeDefined();
+      expect(response.body.totalScore).toBeDefined();
+      expect(response.body.lockedAt).toBeDefined();
+    });
+
+    it('should calculate weighted total score correctly', async () => {
+      const { token: moderatorToken } = await createVerifiedUser('moderator@example.com', 'Moderator');
+      const { sessionId, participantToken, whiskeys } = await createTestSession(moderatorToken);
+
+      await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      const response = await request(app)
+        .post('/api/scores')
+        .set('x-participant-token', participantToken)
+        .send({
+          sessionId,
+          whiskeyId: whiskeys[0].id,
+          nose: 10,
+          palate: 10,
+          finish: 10,
+          overall: 10,
+        });
+
+      // Weighted: nose(10*0.25) + palate(10*0.35) + finish(10*0.25) + overall(10*0.15) = 10
+      expect(response.body.totalScore).toBe(10);
+    });
+
+    it('should reject scores outside valid range', async () => {
+      const { token: moderatorToken } = await createVerifiedUser('moderator@example.com', 'Moderator');
+      const { sessionId, participantToken, whiskeys } = await createTestSession(moderatorToken);
+
+      await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      const response = await request(app)
+        .post('/api/scores')
+        .set('x-participant-token', participantToken)
+        .send({
+          sessionId,
+          whiskeyId: whiskeys[0].id,
+          nose: 11,
+          palate: 7,
+          finish: 8,
+          overall: 8,
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('between 1 and 10');
+    });
+
+    it('should reject duplicate score submission', async () => {
+      const { token: moderatorToken } = await createVerifiedUser('moderator@example.com', 'Moderator');
+      const { sessionId, participantToken, whiskeys } = await createTestSession(moderatorToken);
+
+      await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      await request(app)
+        .post('/api/scores')
+        .set('x-participant-token', participantToken)
+        .send({
+          sessionId,
+          whiskeyId: whiskeys[0].id,
+          nose: 8,
+          palate: 7,
+          finish: 8,
+          overall: 8,
+        });
+
+      const response = await request(app)
+        .post('/api/scores')
+        .set('x-participant-token', participantToken)
+        .send({
+          sessionId,
+          whiskeyId: whiskeys[0].id,
+          nose: 9,
+          palate: 8,
+          finish: 9,
+          overall: 9,
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('already submitted');
+    });
+
+    it('should reject score for inactive session', async () => {
+      const { token: moderatorToken } = await createVerifiedUser('moderator@example.com', 'Moderator');
+      const { sessionId, participantToken, whiskeys } = await createTestSession(moderatorToken);
+
+      const response = await request(app)
+        .post('/api/scores')
+        .set('x-participant-token', participantToken)
+        .send({
+          sessionId,
+          whiskeyId: whiskeys[0].id,
+          nose: 8,
+          palate: 7,
+          finish: 8,
+          overall: 8,
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('not active');
+    });
+
+    it('should reject score without authentication', async () => {
+      const { token: moderatorToken } = await createVerifiedUser('moderator@example.com', 'Moderator');
+      const { sessionId, whiskeys } = await createTestSession(moderatorToken);
+
+      await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      const response = await request(app)
+        .post('/api/scores')
+        .send({
+          sessionId,
+          whiskeyId: whiskeys[0].id,
+          nose: 8,
+          palate: 7,
+          finish: 8,
+          overall: 8,
+        });
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('GET /api/scores/session/:sessionId', () => {
+    it('should return scores after reveal', async () => {
+      const { token: moderatorToken } = await createVerifiedUser('moderator@example.com', 'Moderator');
+      const { sessionId, participantToken, inviteCode, whiskeys } = await createTestSession(moderatorToken);
+
+      await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      await request(app)
+        .post('/api/scores')
+        .set('x-participant-token', participantToken)
+        .send({
+          sessionId,
+          whiskeyId: whiskeys[0].id,
+          nose: 8,
+          palate: 7,
+          finish: 8,
+          overall: 8,
+        });
+
+      const joinResponse = await request(app)
+        .post('/api/sessions/join')
+        .send({
+          inviteCode,
+          displayName: 'Guest Taster',
+        });
+
+      const guestParticipantToken = joinResponse.body.participantToken;
+
+      await request(app)
+        .post('/api/scores')
+        .set('x-participant-token', guestParticipantToken)
+        .send({
+          sessionId,
+          whiskeyId: whiskeys[0].id,
+          nose: 7,
+          palate: 8,
+          finish: 7,
+          overall: 7,
+        });
+
+      await request(app)
+        .post(`/api/sessions/${sessionId}/reveal`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      const response = await request(app)
+        .get(`/api/scores/session/${sessionId}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.results).toBeDefined();
+      expect(response.body.results).toHaveLength(2);
+      expect(response.body.participantCount).toBe(2);
+      expect(response.body.results[0].whiskey).toBeDefined();
+      expect(response.body.results[0].averageScore).toBeDefined();
+      expect(response.body.results[0].ranking).toBeDefined();
+    });
+
+    it('should reject scores request before reveal', async () => {
+      const { token: moderatorToken } = await createVerifiedUser('moderator@example.com', 'Moderator');
+      const { sessionId, participantToken, whiskeys } = await createTestSession(moderatorToken);
+
+      await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      await request(app)
+        .post('/api/scores')
+        .set('x-participant-token', participantToken)
+        .send({
+          sessionId,
+          whiskeyId: whiskeys[0].id,
+          nose: 8,
+          palate: 7,
+          finish: 8,
+          overall: 8,
+        });
+
+      const response = await request(app)
+        .get(`/api/scores/session/${sessionId}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toContain('not yet revealed');
+    });
+  });
+
+  describe('GET /api/scores/my-scores/:sessionId', () => {
+    it('should return participant own scores', async () => {
+      const { token: moderatorToken } = await createVerifiedUser('moderator@example.com', 'Moderator');
+      const { sessionId, participantToken, whiskeys } = await createTestSession(moderatorToken);
+
+      await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      await request(app)
+        .post('/api/scores')
+        .set('x-participant-token', participantToken)
+        .send({
+          sessionId,
+          whiskeyId: whiskeys[0].id,
+          nose: 8,
+          palate: 7,
+          finish: 8,
+          overall: 8,
+        });
+
+      await request(app)
+        .post('/api/scores')
+        .set('x-participant-token', participantToken)
+        .send({
+          sessionId,
+          whiskeyId: whiskeys[1].id,
+          nose: 9,
+          palate: 9,
+          finish: 9,
+          overall: 9,
+        });
+
+      const response = await request(app)
+        .get(`/api/scores/my-scores/${sessionId}`)
+        .set('x-participant-token', participantToken);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveLength(2);
+    });
+  });
+
+  describe('Full Tasting Flow', () => {
+    it('should complete a full tasting session with multiple participants', { timeout: 30000 }, async () => {
+      const { token: moderatorToken } = await createVerifiedUser('moderator@example.com', 'Moderator');
+      const { sessionId, participantToken: modParticipantToken, inviteCode, whiskeys } = await createTestSession(moderatorToken);
+
+      const guest1Response = await request(app)
+        .post('/api/sessions/join')
+        .send({ inviteCode, displayName: 'Guest 1' });
+
+      const guest2Response = await request(app)
+        .post('/api/sessions/join')
+        .send({ inviteCode, displayName: 'Guest 2' });
+
+      const guest1Token = guest1Response.body.participantToken;
+      const guest2Token = guest2Response.body.participantToken;
+
+      await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      const scores = [
+        { token: modParticipantToken, nose: 8, palate: 7, finish: 8, overall: 8 },
+        { token: guest1Token, nose: 7, palate: 8, finish: 7, overall: 7 },
+        { token: guest2Token, nose: 9, palate: 8, finish: 9, overall: 9 },
+      ];
+
+      for (const score of scores) {
+        await request(app)
+          .post('/api/scores')
+          .set('x-participant-token', score.token)
+          .send({
+            sessionId,
+            whiskeyId: whiskeys[0].id,
+            ...score,
+          });
+      }
+
+      await request(app)
+        .post(`/api/sessions/${sessionId}/advance`)
+        .set('Authorization', `Bearer ${moderatorToken}`)
+        .send({ whiskeyIndex: 1, phase: 'pour' });
+
+      const scores2 = [
+        { token: modParticipantToken, nose: 9, palate: 9, finish: 9, overall: 9 },
+        { token: guest1Token, nose: 8, palate: 9, finish: 8, overall: 8 },
+        { token: guest2Token, nose: 7, palate: 7, finish: 7, overall: 7 },
+      ];
+
+      for (const score of scores2) {
+        await request(app)
+          .post('/api/scores')
+          .set('x-participant-token', score.token)
+          .send({
+            sessionId,
+            whiskeyId: whiskeys[1].id,
+            ...score,
+          });
+      }
+
+      const revealResponse = await request(app)
+        .post(`/api/sessions/${sessionId}/reveal`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      expect(revealResponse.status).toBe(200);
+      expect(revealResponse.body.whiskeys).toHaveLength(2);
+      expect(revealResponse.body.scores).toHaveLength(6);
+
+      const resultsResponse = await request(app)
+        .get(`/api/scores/session/${sessionId}`);
+
+      expect(resultsResponse.status).toBe(200);
+      expect(resultsResponse.body.results).toHaveLength(2);
+      expect(resultsResponse.body.participantCount).toBe(3);
+
+      expect(resultsResponse.body.results[0].ranking).toBe(1);
+      expect(resultsResponse.body.results[1].ranking).toBe(2);
+
+      const endResponse = await request(app)
+        .post(`/api/sessions/${sessionId}/end`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      expect(endResponse.status).toBe(200);
+
+      const sessionResponse = await request(app)
+        .get(`/api/sessions/${sessionId}`);
+
+      expect(sessionResponse.body.status).toBe('completed');
+    });
+  });
+});

--- a/server/src/__tests__/integration/sessions.integration.test.ts
+++ b/server/src/__tests__/integration/sessions.integration.test.ts
@@ -1,0 +1,628 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express, { Express } from 'express';
+import cookieParser from 'cookie-parser';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import * as schema from '../../db/schema.js';
+
+// Set JWT_SECRET for tests
+process.env.JWT_SECRET = 'test-jwt-secret-for-integration-tests';
+
+// Create test database instance
+const sqlite = new Database(':memory:');
+sqlite.pragma('foreign_keys = ON');
+const testDb = drizzle(sqlite, { schema });
+
+// Initialize database schema
+sqlite.exec(`
+  CREATE TABLE IF NOT EXISTS users (
+    id TEXT PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    avatar_url TEXT,
+    bio TEXT,
+    favorite_category TEXT,
+    experience_level TEXT,
+    role TEXT NOT NULL DEFAULT 'user',
+    is_profile_public INTEGER NOT NULL DEFAULT 1,
+    email_verified INTEGER NOT NULL DEFAULT 0,
+    verification_code TEXT,
+    verification_code_expires_at INTEGER,
+    reset_password_code TEXT,
+    reset_password_code_expires_at INTEGER,
+    verification_attempts INTEGER NOT NULL DEFAULT 0,
+    verification_locked_until INTEGER,
+    reset_password_attempts INTEGER NOT NULL DEFAULT 0,
+    reset_password_locked_until INTEGER,
+    deleted_at INTEGER,
+    created_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS sessions (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    theme TEXT NOT NULL,
+    custom_theme TEXT,
+    proof_min INTEGER,
+    proof_max INTEGER,
+    scheduled_at INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'draft',
+    moderator_id TEXT NOT NULL REFERENCES users(id),
+    current_whiskey_index INTEGER NOT NULL DEFAULT 0,
+    current_phase TEXT NOT NULL DEFAULT 'pour',
+    invite_code TEXT NOT NULL UNIQUE,
+    max_participants INTEGER,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS whiskeys (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    display_number INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    distillery TEXT NOT NULL,
+    age INTEGER,
+    proof REAL NOT NULL,
+    price REAL,
+    mashbill TEXT,
+    region TEXT,
+    pour_size TEXT NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS participants (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    user_id TEXT REFERENCES users(id),
+    display_name TEXT NOT NULL,
+    joined_at INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'waiting',
+    is_ready INTEGER NOT NULL DEFAULT 0,
+    current_whiskey_index INTEGER NOT NULL DEFAULT 0
+  );
+
+  CREATE TABLE IF NOT EXISTS scores (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    whiskey_id TEXT NOT NULL REFERENCES whiskeys(id) ON DELETE CASCADE,
+    participant_id TEXT NOT NULL REFERENCES participants(id) ON DELETE CASCADE,
+    nose INTEGER NOT NULL,
+    palate INTEGER NOT NULL,
+    finish INTEGER NOT NULL,
+    overall INTEGER NOT NULL,
+    total_score REAL NOT NULL,
+    nose_notes TEXT,
+    palate_notes TEXT,
+    finish_notes TEXT,
+    general_notes TEXT,
+    identity_guess TEXT,
+    is_public INTEGER NOT NULL DEFAULT 0,
+    locked_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token TEXT NOT NULL UNIQUE,
+    expires_at INTEGER NOT NULL,
+    created_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS audit_logs (
+    id TEXT PRIMARY KEY,
+    action TEXT NOT NULL,
+    user_id TEXT,
+    target_user_id TEXT,
+    ip_address TEXT,
+    user_agent TEXT,
+    metadata TEXT,
+    created_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS follows (
+    id TEXT PRIMARY KEY,
+    follower_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    following_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at INTEGER NOT NULL,
+    UNIQUE(follower_id, following_id)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_sessions_invite_code ON sessions(invite_code);
+  CREATE INDEX IF NOT EXISTS idx_participants_session ON participants(session_id);
+`);
+
+// Mock socket.io
+vi.mock('../../socket/index.js', () => ({
+  getIO: () => ({
+    to: () => ({
+      emit: vi.fn(),
+    }),
+  }),
+}));
+
+// Mock email service
+vi.mock('../../services/email.js', () => ({
+  generateVerificationCode: () => 'ABC123',
+  getCodeExpiration: () => new Date(Date.now() + 15 * 60 * 1000),
+  getPasswordResetCodeExpiration: () => new Date(Date.now() + 15 * 60 * 1000),
+  sendVerificationEmail: vi.fn().mockResolvedValue({ success: true, devCode: 'ABC123' }),
+  sendPasswordResetEmail: vi.fn().mockResolvedValue({ success: true, devCode: 'ABC123' }),
+}));
+
+// Mock the db module to use our test database
+vi.mock('../../db/index.js', () => ({
+  db: testDb,
+  schema,
+}));
+
+let app: Express;
+
+async function createTestApp() {
+  const authRoutes = (await import('../../routes/auth.js')).default;
+  const sessionsRoutes = (await import('../../routes/sessions.js')).default;
+
+  const testApp = express();
+  testApp.use(express.json());
+  testApp.use(cookieParser());
+  testApp.use('/api/auth', authRoutes);
+  testApp.use('/api/sessions', sessionsRoutes);
+
+  testApp.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    console.error('Test server error:', err.message);
+    res.status(500).json({ error: 'Internal server error' });
+  });
+
+  return testApp;
+}
+
+async function createVerifiedUser(email: string, displayName: string) {
+  await request(app)
+    .post('/api/auth/register')
+    .send({
+      email,
+      password: 'ValidPassword123!',
+      displayName,
+    });
+
+  const verifyResponse = await request(app)
+    .post('/api/auth/verify-email')
+    .send({
+      email,
+      code: 'ABC123',
+    });
+
+  return {
+    token: verifyResponse.body.accessToken,
+    user: verifyResponse.body.user,
+  };
+}
+
+describe('Sessions Integration Tests', () => {
+  beforeAll(async () => {
+    app = await createTestApp();
+  });
+
+  afterAll(() => {
+    sqlite.close();
+  });
+
+  beforeEach(() => {
+    sqlite.exec(`
+      DELETE FROM audit_logs;
+      DELETE FROM scores;
+      DELETE FROM participants;
+      DELETE FROM whiskeys;
+      DELETE FROM sessions;
+      DELETE FROM follows;
+      DELETE FROM refresh_tokens;
+      DELETE FROM users;
+    `);
+  });
+
+  describe('POST /api/sessions', () => {
+    it('should create a new session', async () => {
+      const { token } = await createVerifiedUser('moderator@example.com', 'Moderator');
+
+      const response = await request(app)
+        .post('/api/sessions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          name: 'Friday Night Tasting',
+          hostName: 'The Moderator',
+          theme: 'bourbon',
+          whiskeys: [
+            { name: 'Buffalo Trace', distillery: 'Buffalo Trace', proof: 90, pourSize: '0.5oz' },
+            { name: 'Makers Mark', distillery: 'Makers Mark', proof: 90, pourSize: '0.5oz' },
+          ],
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body.id).toBeDefined();
+      expect(response.body.inviteCode).toBeDefined();
+      expect(response.body.inviteCode).toHaveLength(6);
+      expect(response.body.participantId).toBeDefined();
+      expect(response.body.participantToken).toBeDefined();
+    });
+
+    it('should reject session creation without authentication', async () => {
+      const response = await request(app)
+        .post('/api/sessions')
+        .send({
+          name: 'Test Session',
+          hostName: 'Host',
+          theme: 'bourbon',
+          whiskeys: [{ name: 'Test', distillery: 'Test', proof: 90, pourSize: '0.5oz' }],
+        });
+
+      expect(response.status).toBe(401);
+    });
+
+    it('should reject session without whiskeys', async () => {
+      const { token } = await createVerifiedUser('moderator@example.com', 'Moderator');
+
+      const response = await request(app)
+        .post('/api/sessions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          name: 'Empty Session',
+          hostName: 'Host',
+          theme: 'bourbon',
+          whiskeys: [],
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('At least one whiskey');
+    });
+
+    it('should reject session with more than 6 whiskeys', async () => {
+      const { token } = await createVerifiedUser('moderator@example.com', 'Moderator');
+
+      const whiskeys = Array(7).fill(null).map((_, i) => ({
+        name: `Whiskey ${i + 1}`,
+        distillery: 'Test',
+        proof: 90,
+        pourSize: '0.5oz',
+      }));
+
+      const response = await request(app)
+        .post('/api/sessions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          name: 'Too Many Whiskeys',
+          hostName: 'Host',
+          theme: 'bourbon',
+          whiskeys,
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('Maximum 6');
+    });
+  });
+
+  describe('GET /api/sessions/:sessionId', () => {
+    it('should get session details', async () => {
+      const { token } = await createVerifiedUser('moderator@example.com', 'Moderator');
+
+      const createResponse = await request(app)
+        .post('/api/sessions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          name: 'Test Session',
+          hostName: 'Moderator',
+          theme: 'bourbon',
+          whiskeys: [{ name: 'Buffalo Trace', distillery: 'Buffalo Trace', proof: 90, pourSize: '0.5oz' }],
+        });
+
+      const sessionId = createResponse.body.id;
+
+      const response = await request(app)
+        .get(`/api/sessions/${sessionId}`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.id).toBe(sessionId);
+      expect(response.body.name).toBe('Test Session');
+      expect(response.body.whiskeys).toHaveLength(1);
+      expect(response.body.participants).toHaveLength(1);
+      expect(response.body.isModerator).toBe(true);
+    });
+
+    it('should return 404 for non-existent session', async () => {
+      const response = await request(app)
+        .get('/api/sessions/non-existent-id');
+
+      expect(response.status).toBe(404);
+    });
+
+    it('should hide whiskey details before reveal', async () => {
+      const { token } = await createVerifiedUser('moderator@example.com', 'Moderator');
+
+      const createResponse = await request(app)
+        .post('/api/sessions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          name: 'Test Session',
+          hostName: 'Moderator',
+          theme: 'bourbon',
+          whiskeys: [{ name: 'Secret Whiskey', distillery: 'Secret Distillery', proof: 100, pourSize: '0.5oz' }],
+        });
+
+      const sessionId = createResponse.body.id;
+
+      const response = await request(app)
+        .get(`/api/sessions/${sessionId}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.whiskeys[0].name).toBeUndefined();
+      expect(response.body.whiskeys[0].distillery).toBeUndefined();
+    });
+  });
+
+  describe('POST /api/sessions/join', () => {
+    it('should allow joining a session with invite code', async () => {
+      const { token } = await createVerifiedUser('moderator@example.com', 'Moderator');
+
+      const createResponse = await request(app)
+        .post('/api/sessions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          name: 'Join Test Session',
+          hostName: 'Moderator',
+          theme: 'bourbon',
+          whiskeys: [{ name: 'Test', distillery: 'Test', proof: 90, pourSize: '0.5oz' }],
+        });
+
+      const inviteCode = createResponse.body.inviteCode;
+
+      const response = await request(app)
+        .post('/api/sessions/join')
+        .send({
+          inviteCode,
+          displayName: 'Guest Taster',
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body.sessionId).toBeDefined();
+      expect(response.body.participantId).toBeDefined();
+      expect(response.body.participantToken).toBeDefined();
+      expect(response.body.isModerator).toBeFalsy(); // null or false for non-moderators
+    });
+
+    it('should reject invalid invite code', async () => {
+      const response = await request(app)
+        .post('/api/sessions/join')
+        .send({
+          inviteCode: 'INVALID',
+          displayName: 'Guest',
+        });
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toContain('not found');
+    });
+
+    it('should reject joining completed session', async () => {
+      const { token } = await createVerifiedUser('moderator@example.com', 'Moderator');
+
+      const createResponse = await request(app)
+        .post('/api/sessions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          name: 'Completed Session',
+          hostName: 'Moderator',
+          theme: 'bourbon',
+          whiskeys: [{ name: 'Test', distillery: 'Test', proof: 90, pourSize: '0.5oz' }],
+        });
+
+      const inviteCode = createResponse.body.inviteCode;
+      const sessionId = createResponse.body.id;
+
+      sqlite.exec(`UPDATE sessions SET status = 'completed' WHERE id = '${sessionId}'`);
+
+      const response = await request(app)
+        .post('/api/sessions/join')
+        .send({
+          inviteCode,
+          displayName: 'Late Guest',
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('ended');
+    });
+  });
+
+  describe('Session Flow - Start, Advance, Reveal, End', () => {
+    let moderatorToken: string;
+    let sessionId: string;
+    let participantToken: string;
+
+    beforeEach(async () => {
+      const { token } = await createVerifiedUser('moderator@example.com', 'Moderator');
+      moderatorToken = token;
+
+      const createResponse = await request(app)
+        .post('/api/sessions')
+        .set('Authorization', `Bearer ${moderatorToken}`)
+        .send({
+          name: 'Flow Test Session',
+          hostName: 'Moderator',
+          theme: 'bourbon',
+          whiskeys: [
+            { name: 'Whiskey 1', distillery: 'Distillery 1', proof: 90, pourSize: '0.5oz' },
+            { name: 'Whiskey 2', distillery: 'Distillery 2', proof: 95, pourSize: '0.5oz' },
+          ],
+        });
+
+      sessionId = createResponse.body.id;
+      participantToken = createResponse.body.participantToken;
+    });
+
+    it('should start a session', async () => {
+      const response = await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.message).toContain('started');
+
+      const sessionResponse = await request(app)
+        .get(`/api/sessions/${sessionId}`);
+
+      expect(sessionResponse.body.status).toBe('active');
+    });
+
+    it('should reject starting already started session', async () => {
+      await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      const response = await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('already started');
+    });
+
+    it('should reject non-moderator from starting session', async () => {
+      const { token: otherToken } = await createVerifiedUser('other@example.com', 'Other User');
+
+      const response = await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${otherToken}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toContain('moderator');
+    });
+
+    it('should advance session phase', async () => {
+      await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      const response = await request(app)
+        .post(`/api/sessions/${sessionId}/advance`)
+        .set('Authorization', `Bearer ${moderatorToken}`)
+        .send({ phase: 'nose' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.phase).toBe('nose');
+    });
+
+    it('should advance to next whiskey', async () => {
+      await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      const response = await request(app)
+        .post(`/api/sessions/${sessionId}/advance`)
+        .set('Authorization', `Bearer ${moderatorToken}`)
+        .send({ whiskeyIndex: 1, phase: 'pour' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.whiskeyIndex).toBe(1);
+    });
+
+    it('should reveal session results', async () => {
+      await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      const response = await request(app)
+        .post(`/api/sessions/${sessionId}/reveal`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.whiskeys).toBeDefined();
+      expect(response.body.whiskeys).toHaveLength(2);
+      expect(response.body.whiskeys[0].name).toBe('Whiskey 1');
+    });
+
+    it('should show whiskey details after reveal', async () => {
+      await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      await request(app)
+        .post(`/api/sessions/${sessionId}/reveal`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      const response = await request(app)
+        .get(`/api/sessions/${sessionId}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.whiskeys[0].name).toBe('Whiskey 1');
+      expect(response.body.whiskeys[0].distillery).toBe('Distillery 1');
+    });
+
+    it('should end a session', async () => {
+      await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      const response = await request(app)
+        .post(`/api/sessions/${sessionId}/end`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.message).toContain('ended');
+
+      const sessionResponse = await request(app)
+        .get(`/api/sessions/${sessionId}`);
+
+      expect(sessionResponse.body.status).toBe('completed');
+    });
+
+    it('should pause and resume a session', async () => {
+      await request(app)
+        .post(`/api/sessions/${sessionId}/start`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      const pauseResponse = await request(app)
+        .post(`/api/sessions/${sessionId}/pause`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      expect(pauseResponse.status).toBe(200);
+
+      const resumeResponse = await request(app)
+        .post(`/api/sessions/${sessionId}/resume`)
+        .set('Authorization', `Bearer ${moderatorToken}`);
+
+      expect(resumeResponse.status).toBe(200);
+    });
+  });
+
+  describe('GET /api/sessions', () => {
+    it('should list user sessions', async () => {
+      const { token } = await createVerifiedUser('moderator@example.com', 'Moderator');
+
+      await request(app)
+        .post('/api/sessions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          name: 'Session 1',
+          hostName: 'Moderator',
+          theme: 'bourbon',
+          whiskeys: [{ name: 'W1', distillery: 'D1', proof: 90, pourSize: '0.5oz' }],
+        });
+
+      await request(app)
+        .post('/api/sessions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          name: 'Session 2',
+          hostName: 'Moderator',
+          theme: 'rye',
+          whiskeys: [{ name: 'W2', distillery: 'D2', proof: 95, pourSize: '0.5oz' }],
+        });
+
+      const response = await request(app)
+        .get('/api/sessions')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveLength(2);
+    });
+  });
+});

--- a/server/src/__tests__/setup.ts
+++ b/server/src/__tests__/setup.ts
@@ -1,0 +1,220 @@
+import express from 'express';
+import cors from 'cors';
+import cookieParser from 'cookie-parser';
+import Database from 'better-sqlite3';
+import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import * as schema from '../db/schema.js';
+import authRoutes from '../routes/auth.js';
+import sessionsRoutes from '../routes/sessions.js';
+import scoresRoutes from '../routes/scores.js';
+import participantsRoutes from '../routes/participants.js';
+import adminRoutes from '../routes/admin.js';
+import socialRoutes from '../routes/social.js';
+
+// Test database instance
+let testDb: BetterSQLite3Database<typeof schema>;
+let sqlite: Database.Database;
+
+/**
+ * Creates an in-memory test database
+ */
+export function createTestDatabase() {
+  sqlite = new Database(':memory:');
+  sqlite.pragma('foreign_keys = ON');
+  testDb = drizzle(sqlite, { schema });
+
+  // Create all tables
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id TEXT PRIMARY KEY,
+      email TEXT NOT NULL UNIQUE,
+      password_hash TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      avatar_url TEXT,
+      bio TEXT,
+      favorite_category TEXT,
+      experience_level TEXT,
+      role TEXT NOT NULL DEFAULT 'user',
+      is_profile_public INTEGER NOT NULL DEFAULT 1,
+      email_verified INTEGER NOT NULL DEFAULT 0,
+      verification_code TEXT,
+      verification_code_expires_at INTEGER,
+      reset_password_code TEXT,
+      reset_password_code_expires_at INTEGER,
+      verification_attempts INTEGER NOT NULL DEFAULT 0,
+      verification_locked_until INTEGER,
+      reset_password_attempts INTEGER NOT NULL DEFAULT 0,
+      reset_password_locked_until INTEGER,
+      deleted_at INTEGER,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS sessions (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      theme TEXT NOT NULL,
+      custom_theme TEXT,
+      proof_min INTEGER,
+      proof_max INTEGER,
+      scheduled_at INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'draft',
+      moderator_id TEXT NOT NULL REFERENCES users(id),
+      current_whiskey_index INTEGER NOT NULL DEFAULT 0,
+      current_phase TEXT NOT NULL DEFAULT 'pour',
+      invite_code TEXT NOT NULL UNIQUE,
+      max_participants INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS whiskeys (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      display_number INTEGER NOT NULL,
+      name TEXT NOT NULL,
+      distillery TEXT NOT NULL,
+      age INTEGER,
+      proof REAL NOT NULL,
+      price REAL,
+      mashbill TEXT,
+      region TEXT,
+      pour_size TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS participants (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      user_id TEXT REFERENCES users(id),
+      display_name TEXT NOT NULL,
+      joined_at INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'waiting',
+      is_ready INTEGER NOT NULL DEFAULT 0,
+      current_whiskey_index INTEGER NOT NULL DEFAULT 0
+    );
+
+    CREATE TABLE IF NOT EXISTS scores (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      whiskey_id TEXT NOT NULL REFERENCES whiskeys(id) ON DELETE CASCADE,
+      participant_id TEXT NOT NULL REFERENCES participants(id) ON DELETE CASCADE,
+      nose INTEGER NOT NULL,
+      palate INTEGER NOT NULL,
+      finish INTEGER NOT NULL,
+      overall INTEGER NOT NULL,
+      total_score REAL NOT NULL,
+      nose_notes TEXT,
+      palate_notes TEXT,
+      finish_notes TEXT,
+      general_notes TEXT,
+      identity_guess TEXT,
+      is_public INTEGER NOT NULL DEFAULT 0,
+      locked_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS refresh_tokens (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      token TEXT NOT NULL UNIQUE,
+      expires_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS follows (
+      id TEXT PRIMARY KEY,
+      follower_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      following_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      created_at INTEGER NOT NULL,
+      UNIQUE(follower_id, following_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS audit_logs (
+      id TEXT PRIMARY KEY,
+      action TEXT NOT NULL,
+      user_id TEXT,
+      target_user_id TEXT,
+      ip_address TEXT,
+      user_agent TEXT,
+      metadata TEXT,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_sessions_invite_code ON sessions(invite_code);
+    CREATE INDEX IF NOT EXISTS idx_participants_session ON participants(session_id);
+    CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user ON refresh_tokens(user_id);
+  `);
+
+  return testDb;
+}
+
+/**
+ * Creates a test Express app instance
+ */
+export function createTestApp() {
+  const app = express();
+
+  app.use(cors({ origin: true, credentials: true }));
+  app.use(express.json());
+  app.use(cookieParser());
+
+  // Health check
+  app.get('/api/health', (req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  // Routes (without CSRF for testing)
+  app.use('/api/auth', authRoutes);
+  app.use('/api/sessions', sessionsRoutes);
+  app.use('/api/scores', scoresRoutes);
+  app.use('/api/participants', participantsRoutes);
+  app.use('/api/admin', adminRoutes);
+  app.use('/api/social', socialRoutes);
+
+  // Error handling
+  app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    console.error('Test server error:', err.message);
+    res.status(500).json({ error: 'Internal server error' });
+  });
+
+  return app;
+}
+
+/**
+ * Get the test database instance
+ */
+export function getTestDb() {
+  return testDb;
+}
+
+/**
+ * Get the raw SQLite instance
+ */
+export function getTestSqlite() {
+  return sqlite;
+}
+
+/**
+ * Close the test database
+ */
+export function closeTestDatabase() {
+  if (sqlite) {
+    sqlite.close();
+  }
+}
+
+/**
+ * Clear all data from test database
+ */
+export function clearTestDatabase() {
+  if (sqlite) {
+    sqlite.exec(`
+      DELETE FROM audit_logs;
+      DELETE FROM follows;
+      DELETE FROM scores;
+      DELETE FROM participants;
+      DELETE FROM whiskeys;
+      DELETE FROM sessions;
+      DELETE FROM refresh_tokens;
+      DELETE FROM users;
+    `);
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     include: ['src/**/*.{test,spec}.{js,ts,tsx}', 'server/**/*.{test,spec}.{js,ts}'],
+    exclude: ['node_modules', 'dist', 'server/dist', 'server/src/__tests__/integration/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['server/src/__tests__/integration/**/*.test.ts'],
+    globals: true,
+    environment: 'node',
+    // Run integration tests sequentially with process isolation
+    fileParallelism: false,
+    isolate: true,
+    testTimeout: 30000,
+    hookTimeout: 30000,
+  },
+});


### PR DESCRIPTION
## Summary
- Add 52 integration tests across 3 test files covering auth, sessions, and scoring API flows
- Add separate vitest configuration for integration tests to run sequentially
- Add `npm run test:integration` script for running integration tests

## Test plan
- [x] Run `npm run test:run` - unit tests pass (115 tests)
- [x] Run `npm run test:integration` - integration tests pass (52 tests)
- [x] Verify tests use in-memory SQLite with mocked socket.io and email services

🤖 Generated with [Claude Code](https://claude.ai/code)