### PR TITLE
Enable trust proxy for proper CSRF and cookie handling

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -36,6 +36,9 @@ validateJwtSecret();
 const app = express();
 const httpServer = createServer(app);
 
+// Trust first proxy (nginx/load balancer) - required for secure cookies and rate limiting behind reverse proxy
+app.set('trust proxy', 1);
+
 // Initialize socket.io
 initializeSocket(httpServer);
 


### PR DESCRIPTION
- Add app.set('trust proxy', 1) to trust first proxy hop
- Fixes CSRF token validation failures behind nginx reverse proxy
- Fixes rate limiting X-Forwarded-For warnings