### PR TITLE
feat: enhance /api/health endpoint with DB check

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,7 +6,8 @@ import { createServer } from 'http';
 import path from 'path';
 import dotenv from 'dotenv';
 
-import { initializeDatabase } from './db/index.js';
+import { db, initializeDatabase } from './db/index.js';
+import { sql } from 'drizzle-orm';
 import { initializeSocket } from './socket/index.js';
 import { validateJwtSecret } from './middleware/auth.js';
 import { generalLimiter } from './middleware/rateLimit.js';
@@ -83,7 +84,23 @@ app.use('/uploads', (req, res, next) => {
 
 // Health check
 app.get('/api/health', (req, res) => {
-  res.json({ status: 'ok', timestamp: new Date().toISOString() });
+  let dbStatus = 'ok';
+  try {
+    db.run(sql`SELECT 1`);
+  } catch {
+    dbStatus = 'error';
+  }
+
+  const status = dbStatus === 'ok' ? 'ok' : 'degraded';
+  res.status(status === 'ok' ? 200 : 503).json({
+    status,
+    service: 'whiskey-canon-blinds',
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString(),
+    checks: {
+      database: dbStatus,
+    },
+  });
 });
 
 // CSRF token endpoint - requires authentication, must be before CSRF protection middleware


### PR DESCRIPTION
## Summary
Enhance the existing health endpoint with database connectivity check and structured response.

## Changes
- **server/src/index.ts**: Enhanced `/api/health` with DB check, uptime, service name; added `sql` import from drizzle-orm

## Response Format
```json
{
  "status": "ok",
  "service": "whiskey-canon-blinds",
  "uptime": 3600,
  "timestamp": "2026-03-17T00:00:00Z",
  "checks": { "database": "ok" }
}
```

## Test Plan
- [x] Returns 200 with `status: ok` when DB is accessible
- [x] Returns 503 with `status: degraded` when DB is down
- [x] No auth required

Closes #56